### PR TITLE
FIX : 피드 프로필 사진 에러 수정

### DIFF
--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -10,7 +10,7 @@ import "swiper/css";
 import "swiper/css/pagination";
 import { UserStore } from "../store/userStore";
 import AlertModal from "./alertModal";
-import SouFLogo from "../assets/images/SouFLogo.png";
+import BasicProfileImg from "../assets/images/BasicProfileImg1.png";
 
 const BUCKET_URL = import.meta.env.VITE_S3_BUCKET_URL;
 
@@ -114,7 +114,7 @@ export default function Feed({ feedData }) {
       <div className="w-full max-w-[500px] flex justify-start items-center mb-2 gap-2 cursor-pointer"
       onClick={() => clickHandler(feedData?.memberId)}>
          <img
-            src={feedData?.profileUrl ? `${BUCKET_URL}${feedData?.profileUrl}` : SouFLogo}
+            src={feedData?.profileUrl ? `${BUCKET_URL}${feedData?.profileUrl}` : BasicProfileImg}
             alt={feedData?.topic || "이미지"}
             className="w-[40px] h-[40px] object-cover rounded-[50%]"
           />

--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -10,6 +10,7 @@ import "swiper/css";
 import "swiper/css/pagination";
 import { UserStore } from "../store/userStore";
 import AlertModal from "./alertModal";
+import SouFLogo from "../assets/images/SouFLogo.png";
 
 const BUCKET_URL = import.meta.env.VITE_S3_BUCKET_URL;
 
@@ -30,7 +31,6 @@ export default function Feed({ feedData }) {
     size: 10,
   });
   
-
   if (loading) {
     return (
       <div className="flex justify-center items-center h-48">
@@ -114,7 +114,7 @@ export default function Feed({ feedData }) {
       <div className="w-full max-w-[500px] flex justify-start items-center mb-2 gap-2 cursor-pointer"
       onClick={() => clickHandler(feedData?.memberId)}>
          <img
-            src={`https://iamsouf-bucket.s3.ap-northeast-2.amazonaws.com/${feedData?.profileUrl}`}
+            src={feedData?.profileUrl ? `${BUCKET_URL}${feedData?.profileUrl}` : SouFLogo}
             alt={feedData?.topic || "이미지"}
             className="w-[40px] h-[40px] object-cover rounded-[50%]"
           />


### PR DESCRIPTION

## 🔗 연관된 이슈

> #

## 🛠️ 작업 내용

> 피드 프로필 사진 없는 경우 사진이 보이지 않는 에러(? 아이콘이 뜨는 에러) 해결
프로필 사진이 없는 경우, 스프 기본 로고로 대체하였습니다.

## 📸 스크린샷
<img width="340" alt="스크린샷 2025-07-08 오후 1 52 25" src="https://github.com/user-attachments/assets/120fc127-3b91-4827-8cdd-02059974cf45" />

수정 전

<img width="329" alt="스크린샷 2025-07-08 오후 1 52 37" src="https://github.com/user-attachments/assets/51d0283a-28b7-46fd-8e70-46023a5dccf2" />

수정 후 

## 💬 리뷰 요구사항

> 사진이 없는 경우 스프 기본 로고로 대체할 지, `BasicProfileImg`로 대체할 지 고민해봅시다



