### PR TITLE
DESIGN : 피드 비율 고정

### DIFF
--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -160,7 +160,7 @@ export default function Feed({ feedData, onFeedClick }) {
                         <img
                           src={`${BUCKET_URL}${data.fileUrl}`}
                           alt={data.fileName}
-                          className="w-full object-cover rounded-lg"
+                          className="w-full h-auto max-h-[500px] object-cover rounded-lg aspect-[3/4]"
                         />
                       )}
                     </div>

--- a/src/pages/studentFeedList.jsx
+++ b/src/pages/studentFeedList.jsx
@@ -52,9 +52,11 @@ export default function StudentFeedList() {
   return (
     <div className="w-full flex flex-col items-center justify-center w-full">
       {feedData?.result?.content && feedData.result.content.length > 0 ? (
-        feedData.result.content.map((data) => (
-        <Feed key={data.memberId} feedData={data} onFeedClick={onFeedClick} />
-        ))
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 w-full max-w-7xl">
+          {feedData.result.content.map((data) => (
+            <Feed key={data.memberId} feedData={data} onFeedClick={onFeedClick} />
+          ))}
+        </div>
       ) : (
         <div className="text-center py-10">
           <p className="text-gray-500 text-lg">


### PR DESCRIPTION
## 🔗 연관된 이슈

> #

## 🛠️ 작업 내용

> 피드백에 맞게 피드 작업물을 2열 그리드로 만들고, 사진 최대 높이를 설정했습니다. (2열이라 옆의 사진이 작은경우 남은 공간이 너무 비는 문제)
> 홈 화면 캐러셀 슬라이드 -> 모바일에서는 스와이퍼로 

## 📸 스크린샷
<img width="1680" height="970" alt="스크린샷 2025-07-16 오후 2 23 35" src="https://github.com/user-attachments/assets/599b9622-e251-4874-9f0c-82e3bd0fe92f" />

홈화면 캐러셀
이전 
<img width="394" height="685" alt="스크린샷 2025-07-16 오후 7 04 26" src="https://github.com/user-attachments/assets/f1711025-d375-48b8-877a-e5954fd02e08" />
: 캐러셀 슬라이드

이후
<img width="391" height="678" alt="스크린샷 2025-07-16 오후 7 04 39" src="https://github.com/user-attachments/assets/95f127f7-7424-4bf1-abcb-d717ab35d6fd" />
: 스와이퍼

## 💬 리뷰 요구사항

> 



