### PR TITLE
DESIGN : 반응형 홈 여백 제거 & 로그인 크기 수정 

### DIFF
--- a/src/components/home/mobileSwiper.jsx
+++ b/src/components/home/mobileSwiper.jsx
@@ -28,7 +28,7 @@ export default function MobileSwiper() {
   }
 
   return (
-    <div className="relative w-screen px-4 mt-4 lg:hidden">
+    <div className="relative w-screen mt-4 lg:hidden">
       <Swiper
         slidesPerView={2} // 모바일 한 번에 1개 슬라이드
         spaceBetween={0}  // 슬라이드 간격
@@ -39,7 +39,7 @@ export default function MobileSwiper() {
         {recruitData.map((recruit) => (
           <SwiperSlide key={recruit.recruitId} className="box-border min-w-0">
             <div
-              className="w-84 box-border h-64 px-3 cursor-pointer"
+              className="w-84 box-border h-64 px-6 cursor-pointer"
               onClick={() => navigate(`/recruitDetails/${recruit.recruitId}`)}
             >
               <div className="h-60 bg-white rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden border border-gray-100">

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -304,7 +304,7 @@ export default function Home() {
         </div>
       </div>
       {/* 모바일 버전 인기 공고문 섹션 : 스와이퍼 */}
-      <div className="relative mt-16 px-4 block lg:hidden">
+      <div className="relative mt-16 block lg:hidden">
         <div className="relative flex flex-col  mx-auto lg:px-6 py-16 overflow-x-hidden">
           <h2 className="text-2xl  font-bold mb-8 px-6">
             <span className="relative inline-block ">

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -82,9 +82,10 @@ export default function Login() {
           </p>
          
         </div>
-      <div className="w-full lg:w-1/2 lg:bg-white flex flex-col justify-center items-center px-36 h-full">
-        <h2 className="text-3xl lg:text-6xl font-bold mb-10 mx-auto">로그인</h2>
-        <div className="w-[400px] space-y-6 bg-white p-6 lg:p-8 border rounded-xl shadow">
+        <div className="w-full lg:w-1/2 lg:bg-white flex flex-col justify-center items-center px-4 h-full">
+  <h2 className="text-3xl lg:text-6xl font-bold mb-10 mx-auto">로그인</h2>
+
+  <div className="w-full max-w-sm bg-white p-6 lg:p-8 border rounded-xl shadow">
           <Input
             title="이메일"
             // isValidateTrigger={isValidateTrigger}


### PR DESCRIPTION

## 🔗 연관된 이슈

> #

## 🛠️ 작업 내용

> padding 값으로 인한 반응형 홈 여백 제거 & 너비가 좁은 화면에서 로그인 박스 깨지는 현상으로 로그인 크기 수정 

## 📸 스크린샷
홈 이전
<img width="399" height="348" alt="스크린샷 2025-07-16 오후 8 33 41" src="https://github.com/user-attachments/assets/010c21d5-98c3-46da-a9c5-ab550b767542" />

홈 이후
<img width="392" height="358" alt="스크린샷 2025-07-16 오후 8 33 47" src="https://github.com/user-attachments/assets/b4817f9f-d244-4d8b-971f-09f202efb4b0" />



## 💬 리뷰 요구사항

> 



