### PR TITLE
DESIGN : Swiper 높이, 폰트 크기 수정

### DIFF
--- a/src/components/home/mobileSwiper.jsx
+++ b/src/components/home/mobileSwiper.jsx
@@ -95,7 +95,7 @@ export default function MobileSwiper() {
         loop={true}
         speed={700}
         autoplay={{
-          delay:10000,
+          delay:4000,
           disableOnInteraction: false,
         }}
         modules={[Autoplay]}
@@ -113,7 +113,7 @@ export default function MobileSwiper() {
                   </h3>
                 </div>
                 <div className="px-6 pb-4">
-                  <span className="inline-block px-3 py-1 bg-yellow-point/10 text-yellow-point text-sm font-semibold rounded-full">
+                  <span className="inline-block px-3 py-1 bg-yellow-point/10 text-yellow-point text-md font-semibold rounded-full">
                     {getSecondCategoryNameById(recruit.secondCategory)}
                   </span>
                 </div>


### PR DESCRIPTION

## 🔗 연관된 이슈

> #

## 🛠️ 작업 내용

> Swiper 높이가 잘리지 않도록 h-64 -> h-80으로 수정, 폰트 크기 키움

## 📸 스크린샷

수정 전
<img width="772" height="258" alt="스크린샷 2025-07-23 오후 2 58 49" src="https://github.com/user-attachments/assets/cc788b08-f9ff-43ce-a788-783d914a4f89" />

수정 후
<img width="782" height="267" alt="스크린샷 2025-07-23 오후 2 58 53" src="https://github.com/user-attachments/assets/8d818569-3654-41c3-a881-c01932e39496" />

## 💬 리뷰 요구사항

> 



