### PR TITLE
FEAT : 403 리다이렉트 유저 정보 삭제

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -32,16 +32,17 @@ export default function Header() {
   const categoryFromQuery = query.get("category");
 
   useEffect(() => {
-    const loginStatus = localStorage.getItem("isLogin");
-    if (loginStatus === "true") {
+    // userStore의 memberId가 있으면 로그인 상태로 간주
+    if (memberId) {
       setIsLogin(true);
-
-      const type = localStorage.getItem("userType") || "student";
-      const name = localStorage.getItem("userName") || "";
-      setUserType(type);
-      setUserName(name);
+      setUserType(roleType || "student");
+      setUserName(nickname || "");
+    } else {
+      setIsLogin(false);
+      setUserType("");
+      setUserName("");
     }
-  }, []);
+  }, [memberId, roleType, nickname]);
 
   useEffect(() => {
     // /recruit 경로 & 카테고리 쿼리 파라미터가 있는 경우만

--- a/src/pages/forbidden.jsx
+++ b/src/pages/forbidden.jsx
@@ -1,22 +1,41 @@
 import warningIco from '../assets/images/warningIco.svg'
 import SEO from '../components/seo';
+import { useEffect } from 'react';
+import { UserStore } from '../store/userStore';
+
 export default function Forbidden() {
-    return (
-      <>
-      <SEO title="오류" description="스프 SouF 오류" subTitle="스프"/>
-      <div className="w-full flex flex-col items-center justify-center min-h-screen bg-gray-100 text-center px-4">
-        <img src={warningIco} alt="warning" className="w-40 h-40 mb-4" />
-        <h1 className="text-4xl font-bold text-red-500 mb-4">접근이 거부되었습니다</h1>
-        <p className="mb-6 text-gray-700">인증이 만료되었거나 권한이 없습니다. 다시 로그인해주세요.</p>
-        <a
-          href="/login"
-          className="px-4 py-2 bg-yellow-main text-gray-700 rounded-lg"
-        >
-          로그인 페이지로 이동
-        </a>
-      </div>
-      </>
-      
-    );
-  }
+  useEffect(() => {
+    // 403 에러 발생 시 모든 로그인 정보 정리
+    const userStore = UserStore.getState();
+    
+    // userStore 초기화
+    userStore.clearUser();
+    
+    // 로컬 스토리지 초기화
+    localStorage.removeItem("isLogin");
+    localStorage.removeItem("userType");
+    localStorage.removeItem("userName");
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+    localStorage.removeItem("user-storage");
+  }, []);
+
+  return (
+    <>
+    <SEO title="오류" description="스프 SouF 오류" subTitle="스프"/>
+    <div className="w-full flex flex-col items-center justify-center min-h-screen bg-gray-100 text-center px-4">
+      <img src={warningIco} alt="warning" className="w-40 h-40 mb-4" />
+      <h1 className="text-4xl font-bold text-red-500 mb-4">접근이 거부되었습니다</h1>
+      <p className="mb-6 text-gray-700">인증이 만료되었거나 권한이 없습니다. 다시 로그인해주세요.</p>
+      <a
+        href="/login"
+        className="px-4 py-2 bg-yellow-main text-gray-700 rounded-lg"
+      >
+        로그인 페이지로 이동
+      </a>
+    </div>
+    </>
+    
+  );
+}
   


### PR DESCRIPTION

## 🔗 연관된 이슈

> #

## 🛠️ 작업 내용

> 403 에러가 떠서 오류 페이지로 리다이렌트해도 헤더에 유저 정보가 남아있던 문제 해결

- `forbidden.jsx`
-- 403 에러 페이지에 접근할 때 useEffect를 추가하여 모든 로그인 정보를 정리
-- userStore의 clearUser() 호출
-- 로컬 스토리지의 모든 관련 항목 삭제



