### PR TITLE
DESIGN : 피드 페이지 날짜 위치 수정

### DIFF
--- a/src/components/AnimatedCount.jsx
+++ b/src/components/AnimatedCount.jsx
@@ -5,13 +5,13 @@ export default function AnimatedCount({ value, prevValue }) {
     <span className="relative inline-block w-40 h-10 overflow-hidden align-middle">
       <span
         key={prevValue}
-        className="absolute left-0 top-0 w-full h-full flex items-center justify-center text-inherit animate-countup-out"
+        className="absolute py-1 left-0 top-0 w-full h-full flex items-center justify-center text-inherit animate-countup-out"
       >
         {prevValue.toLocaleString()}
       </span>
       <span
         key={value}
-        className="absolute left-0 top-0 w-full h-full flex items-center justify-center text-inherit animate-countup-in"
+        className="absolute py-1 left-0 top-0 w-full h-full flex items-center justify-center text-inherit animate-countup-in"
       >
         {value.toLocaleString()}
       </span>

--- a/src/components/studentProfile/postDetail.jsx
+++ b/src/components/studentProfile/postDetail.jsx
@@ -199,7 +199,7 @@ const handleDeleteClick = () => {
     )}
   </div>
           
-          <div className="w-full max-w-[35%] h-full min-h-[240px] pl-6 relative ">
+          <div className="w-full max-w-[35%] pl-6 relative ">
             {/* 사용자 프로필 정보 */}
         <div className="flex items-center justify-between mb-4 w-full">
           {/* 프로필 사진과 닉네임 (왼쪽) */}
@@ -276,20 +276,21 @@ const handleDeleteClick = () => {
         </div>
             
             
-          <div className="flex flex-col justify-end items-start mb-4 h-[80%]">
-            <div className="w-full">
-              <div className="flex justify-between items-center text-xl font-semibold leading-snug text-black py-3 ">
+          <div className="flex flex-col justify-end items-start mb-4 h-[90%] w-full ">
+            <div className="w-full h-full flex justify-between flex-col">
+              <div className="w-full">
+              <div className="w-full text-xl font-semibold leading-snug text-black py-3 ">
               {worksData.topic}
               </div>
-              <div className="flex flex-col justify-between text-sm text-gray-600 h-full w-full border-t border-gray-300 pt-6">
+              <div className="w-full text-sm text-gray-600 border-t border-gray-300">
                 <p className="whitespace-pre-wrap text-gray-800 leading-relaxed text-md">
                 {worksData.content}
                 </p>
               </div>
+              </div>
+              <p className="text-right">{getFormattedDate(worksData.lastModifiedTime)}</p>
             </div>
-            <div className="ml-auto mt-4">
-              <p className="">{getFormattedDate(worksData.lastModifiedTime)}</p>
-            </div>
+            
             </div>
            
           </div>


### PR DESCRIPTION

## 🔗 연관된 이슈

> #

## 🛠️ 작업 내용

> 피드 상세 페이지의 날짜 위치를 조정했습니다.

## 📸 스크린샷
수정 전
<img width="513" height="393" alt="스크린샷 2025-08-01 오전 1 10 35" src="https://github.com/user-attachments/assets/084c12f5-8869-46c1-a165-02ad8623ab34" />

수정 후
<img width="519" height="450" alt="스크린샷 2025-08-01 오전 1 10 14" src="https://github.com/user-attachments/assets/a26a3b89-60ba-4610-a440-b1394bf4bd7e" />



## 💬 리뷰 요구사항

> 



