### PR TITLE
DESIGN : 인기 피드&공고문 Swiper+navigate 화살표 추가

### DIFF
--- a/src/components/home/feedSwiper.jsx
+++ b/src/components/home/feedSwiper.jsx
@@ -3,6 +3,7 @@ import { usePopularFeed } from "../../hooks/usePopularFeed";
 import { useNavigate } from "react-router-dom";
 import { UserStore } from "../../store/userStore";
 import AlertModal from "../alertModal";
+import firstCategoryData from "../../assets/categoryIndex/first_category.json";
 
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay } from "swiper/modules";
@@ -18,6 +19,12 @@ export default function FeedSwiper() {
   const { data, isLoading, error } = usePopularFeed(pageable);
 
   const BUCKET_URL = import.meta.env.VITE_S3_BUCKET_URL;
+
+  // 카테고리 ID를 이름으로 변환하는 함수
+  const getCategoryName = (categoryId) => {
+    const category = firstCategoryData.first_category.find(cat => cat.first_category_id === categoryId);
+    return category ? category.name : `카테고리 ${categoryId}`;
+  };
 
   useEffect(() => {
     console.log("Feed data from API:", data);
@@ -55,23 +62,43 @@ export default function FeedSwiper() {
   return (
     <div className="relative w-screen mt-4 lg:px-24">
       <Swiper
-        slidesPerView={4}
-        spaceBetween={0}
-        loop={feedData.length > 4}
+        slidesPerView={2}
+        spaceBetween={10}
+        loop={feedData.length > 2}
         speed={700}
         autoplay={feedData.length > 2 ? {
           delay: 4000,
           disableOnInteraction: false,
         } : false}
+        breakpoints={{
+          640: {
+            slidesPerView: 2,
+            spaceBetween: 15,
+            loop: feedData.length > 2,
+            autoplay: feedData.length > 2 ? {
+              delay: 4000,
+              disableOnInteraction: false,
+            } : false,
+          },
+          1024: {
+            slidesPerView: 4,
+            spaceBetween: 0,
+            loop: feedData.length > 4,
+            autoplay: feedData.length > 4 ? {
+              delay: 4000,
+              disableOnInteraction: false,
+            } : false,
+          },
+        }}
         modules={[Autoplay]}
       >
        
         {feedData.map((feed) => (
-          <SwiperSlide key={feed.feedId} className="box-border min-w-0">
+          <SwiperSlide key={feed.feedId} className="box-border min-w-0 px-4">
                           <div
-                className="w-80 box-border h-[500px] mb-2 px-6 cursor-pointer"
+                className="w-full lg:w-72 box-border h-[400px] sm:h-[440px] lg:h-[500px] mb-2 px-2 lg:px-4 lg:px-6 cursor-pointer"
                 onClick={() => handleClick(feed?.feedId, feed?.memberId)}>
-                <div className="h-[500px] bg-white rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden border border-gray-100">
+                <div className="h-full bg-white rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden border border-gray-100">
                 {/* 피드 이미지 */}
                 {feed.mediaResDto?.fileUrl && (
                   <div className="w-full aspect-[3/4] bg-gray-100 overflow-hidden">
@@ -86,13 +113,13 @@ export default function FeedSwiper() {
                   </div>
                 )}
                 {/* 카드 내용 */}
-                <div className="px-6 pt-4">
-                  <span className="inline-block px-3 py-1 bg-yellow-point/10 text-yellow-point text-md font-semibold rounded-full">
-                    카테고리 {feed.firstCategories?.join(', ')}
+                <div className="px-2 lg:px-6 pt-4">
+                  <span className="inline-block px-2 lg:px-3 py-1 bg-yellow-point/10 text-yellow-point text-sm lg:text-md font-semibold rounded-full">
+                    {feed.firstCategories?.map(categoryId => getCategoryName(categoryId)).join(', ')}
                   </span>
                 </div>
-                <div className="px-6 pb-3 text-right">
-                  <h3 className="text-2xl font-bold text-gray-800 line-clamp-2">
+                <div className="px-2 lg:px-6 pb-3 text-right">
+                  <h3 className="text-lg lg:text-xl lg:text-2xl font-bold text-gray-800 line-clamp-2">
                     {feed.nickname}
                   </h3>
                 </div>

--- a/src/components/home/feedSwiper.jsx
+++ b/src/components/home/feedSwiper.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { usePopularFeed } from "../../hooks/usePopularFeed";
+import { useNavigate } from "react-router-dom";
+import { UserStore } from "../../store/userStore";
+import AlertModal from "../alertModal";
+
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Autoplay } from "swiper/modules";
+import "swiper/css";
+
+export default function FeedSwiper() {
+  const [feedData, setFeedData] = useState([]);
+  const navigate = useNavigate();
+  const { memberId } = UserStore();
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const pageable = { page: 0, size: 12, sort: ["createdAt,desc"] };
+
+  const { data, isLoading, error } = usePopularFeed(pageable);
+
+  const BUCKET_URL = import.meta.env.VITE_S3_BUCKET_URL;
+
+  useEffect(() => {
+    console.log("Feed data from API:", data);
+    console.log("Feed result:", data?.result);
+    setFeedData(data?.result || []);
+  }, [data]);
+
+  useEffect(() => {
+    console.log("Current feedData state:", feedData);
+  }, [feedData]);
+
+  // 에러 로그 추가
+  useEffect(() => {
+    if (error) {
+      console.error("Feed API error:", error);
+    }
+  }, [error]);
+
+  const handleClick = (feedId, memberId) => {
+    if (!memberId) {
+      setShowLoginModal(true);
+    } else {
+      navigate(`/profileDetail/${memberId}/post/${feedId}`);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="h-80 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-point"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-screen mt-4 lg:px-24">
+      <Swiper
+        slidesPerView={4}
+        spaceBetween={0}
+        loop={feedData.length > 4}
+        speed={700}
+        autoplay={feedData.length > 2 ? {
+          delay: 4000,
+          disableOnInteraction: false,
+        } : false}
+        modules={[Autoplay]}
+      >
+       
+        {feedData.map((feed) => (
+          <SwiperSlide key={feed.feedId} className="box-border min-w-0">
+                          <div
+                className="w-80 box-border h-[500px] mb-2 px-6 cursor-pointer"
+                onClick={() => handleClick(feed?.feedId, feed?.memberId)}>
+                <div className="h-[500px] bg-white rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden border border-gray-100">
+                {/* 피드 이미지 */}
+                {feed.mediaResDto?.fileUrl && (
+                  <div className="w-full aspect-[3/4] bg-gray-100 overflow-hidden">
+                    <img 
+                      src={`${BUCKET_URL}${feed.mediaResDto.fileUrl}`} 
+                      alt="피드 이미지"
+                      className="w-full h-full object-cover"
+                      onError={(e) => {
+                        e.target.style.display = 'none';
+                      }}
+                    />
+                  </div>
+                )}
+                {/* 카드 내용 */}
+                <div className="px-6 pt-4">
+                  <span className="inline-block px-3 py-1 bg-yellow-point/10 text-yellow-point text-md font-semibold rounded-full">
+                    카테고리 {feed.firstCategories?.join(', ')}
+                  </span>
+                </div>
+                <div className="px-6 pb-3 text-right">
+                  <h3 className="text-2xl font-bold text-gray-800 line-clamp-2">
+                    {feed.nickname}
+                  </h3>
+                </div>
+              </div>
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      {showLoginModal && (
+        <AlertModal
+          type="simple"
+          title="로그인이 필요합니다"
+          description="SouF 회원만 상세 글을 조회할 수 있습니다!"
+          TrueBtnText="로그인하러 가기"
+          FalseBtnText="취소"
+          onClickTrue={() => {
+            setShowLoginModal(false);
+            navigate("/login");
+          }}
+          onClickFalse={() => setShowLoginModal(false)}
+        />
+      )}
+    </div>
+  );
+} 

--- a/src/components/home/feedSwiper.jsx
+++ b/src/components/home/feedSwiper.jsx
@@ -4,10 +4,18 @@ import { useNavigate } from "react-router-dom";
 import { UserStore } from "../../store/userStore";
 import AlertModal from "../alertModal";
 import firstCategoryData from "../../assets/categoryIndex/first_category.json";
-
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Autoplay } from "swiper/modules";
+import { Autoplay, Navigation } from "swiper/modules";
 import "swiper/css";
+import "swiper/css/navigation";
+
+// Swiper 기본 navigation 스타일 오버라이드
+const swiperStyles = `
+  .swiper-button-prev,
+  .swiper-button-next {
+    display: none !important;
+  }
+`;
 
 export default function FeedSwiper() {
   const [feedData, setFeedData] = useState([]);
@@ -60,7 +68,23 @@ export default function FeedSwiper() {
   }
 
   return (
-    <div className="relative w-screen mt-4 lg:px-24">
+    <>
+      <style>{swiperStyles}</style>
+      <div className="relative w-screen lg:px-24 mx-auto mt-4">
+            {/* 이전 버튼 */}
+      <button className="custom-prev absolute left-4 lg:left-8 top-1/2 transform -translate-y-1/2 z-10 w-12 h-12 flex items-center justify-center hover:scale-110 transition-transform duration-200">
+        <svg className="w-12 h-12 text-yellow-point" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+      
+      {/* 다음 버튼 */}
+      <button className="custom-next absolute right-4 lg:right-8 top-1/2 transform -translate-y-1/2 z-10 w-12 h-12 flex items-center justify-center hover:scale-110 transition-transform duration-200">
+        <svg className="w-12 h-12 text-yellow-point" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+      
       <Swiper
         slidesPerView={2}
         spaceBetween={10}
@@ -83,20 +107,24 @@ export default function FeedSwiper() {
           1024: {
             slidesPerView: 4,
             spaceBetween: 0,
-            loop: feedData.length > 4,
+            loop: feedData.length > 3,
             autoplay: feedData.length > 4 ? {
               delay: 4000,
               disableOnInteraction: false,
             } : false,
           },
         }}
-        modules={[Autoplay]}
+        navigation={{
+          nextEl: '.custom-next',
+          prevEl: '.custom-prev',
+        }}
+        modules={[Autoplay, Navigation]}
       >
        
         {feedData.map((feed) => (
           <SwiperSlide key={feed.feedId} className="box-border min-w-0 px-4">
                           <div
-                className="w-full lg:w-72 box-border h-[400px] sm:h-[440px] lg:h-[500px] mb-2 px-2 lg:px-4 lg:px-6 cursor-pointer"
+                className="w-full lg:w-80 box-border h-[400px] sm:h-[440px] lg:h-[500px] mb-2 px-2 lg:px-4 lg:px-6 cursor-pointer mx-auto"
                 onClick={() => handleClick(feed?.feedId, feed?.memberId)}>
                 <div className="h-full bg-white rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden border border-gray-100">
                 {/* 피드 이미지 */}
@@ -142,6 +170,7 @@ export default function FeedSwiper() {
           onClickFalse={() => setShowLoginModal(false)}
         />
       )}
-    </div>
+      </div>
+    </>
   );
 } 

--- a/src/components/home/mobileSwiper.jsx
+++ b/src/components/home/mobileSwiper.jsx
@@ -8,8 +8,17 @@ import AlertModal from "../alertModal";
 import { getRecruitDetail } from "../../api/recruit";
 
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Autoplay } from "swiper/modules";
+import { Autoplay, Navigation } from "swiper/modules";
 import "swiper/css";
+import "swiper/css/navigation";
+
+// Swiper 기본 navigation 스타일 오버라이드
+const swiperStyles = `
+  .swiper-button-prev,
+  .swiper-button-next {
+    display: none !important;
+  }
+`;
 
 export default function MobileSwiper() {
   const [recruitData, setRecruitData] = useState([]);
@@ -84,7 +93,23 @@ export default function MobileSwiper() {
   }
 
   return (
-    <div className="relative w-screen mt-4 lg:px-24">
+    <>
+      <style>{swiperStyles}</style>
+      <div className="relative  w-screen lg:px-24  mt-4">
+      {/* 이전 버튼 */}
+      <button className="custom-prev absolute left-4 lg:left-8 top-1/2 transform -translate-y-1/2 z-10 w-12 h-12 flex items-center justify-center hover:scale-110 transition-transform duration-200">
+        <svg className="w-12 h-12 text-yellow-point" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+      
+      {/* 다음 버튼 */}
+      <button className="custom-next absolute right-4 lg:right-8 top-1/2 transform -translate-y-1/2 z-10 w-12 h-12 flex items-center justify-center hover:scale-110 transition-transform duration-200">
+        <svg className="w-12 h-12 text-yellow-point" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+      
       <Swiper
         slidesPerView={2}
         spaceBetween={0}
@@ -94,12 +119,16 @@ export default function MobileSwiper() {
           delay:4000,
           disableOnInteraction: false,
         } : false}
-        modules={[Autoplay]}
+        navigation={{
+          nextEl: '.custom-next',
+          prevEl: '.custom-prev',
+        }}
+        modules={[Autoplay, Navigation]}
       >
         {recruitData.map((recruit) => (
-          <SwiperSlide key={recruit.recruitId} className="box-border min-w-0">
+          <SwiperSlide key={recruit.recruitId} className="box-border min-w-0 ">
             <div
-              className="w-84 box-border h-80 px-6 cursor-pointer"
+              className="w-84 box-border h-64 mb-4 px-6 cursor-pointer"
               onClick={() => handleClick(recruit?.recruitId)}>
               <div className="h-64 bg-white rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden border border-gray-100">
                 {/* 카드 내용 */}
@@ -148,6 +177,7 @@ export default function MobileSwiper() {
           onClickFalse={() => setShowLoginModal(false)}
         />
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/components/home/mobileSwiper.jsx
+++ b/src/components/home/mobileSwiper.jsx
@@ -88,12 +88,12 @@ export default function MobileSwiper() {
       <Swiper
         slidesPerView={2}
         spaceBetween={0}
-        loop={true}
+        loop={recruitData.length > 2}
         speed={700}
-        autoplay={{
+        autoplay={recruitData.length > 2 ? {
           delay:4000,
           disableOnInteraction: false,
-        }}
+        } : false}
         modules={[Autoplay]}
       >
         {recruitData.map((recruit) => (

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -5,18 +5,20 @@ import { Helmet } from "react-helmet-async";
 
 
 export default function SEO({ title, subTitle ="", description, content }) {
+  // title과 subTitle이 유효한 문자열인지 확인
+  const safeTitle = title || "SouF";
+  const safeSubTitle = subTitle || "대학생 외주 & 공모전";
 
-    useEffect(() => {
-    if (title) {
-      document.title = `${title} | ${subTitle}`;
-    }
-  }, [title, subTitle,content]);
+  useEffect(() => {
+    document.title = `${safeTitle} | ${safeSubTitle}`;
+  }, [safeTitle, safeSubTitle]);
+
   return (
     <Helmet>
-      <title>{title} | {subTitle}</title>
-      <meta property="og:title" content={`${title} | SouF`} />
-      <meta property="og:description" content={content} />
-      <meta property="description" content={content} />
+      <title>{`${safeTitle} | ${safeSubTitle}`}</title>
+      <meta property="og:title" content={`${safeTitle} | SouF`} />
+      <meta property="og:description" content={content || description || "스프 SouF 대학생 외주 공모전"} />
+      <meta property="description" content={content || description || "스프 SouF 대학생 외주 공모전"} />
       <meta charSet="utf-8" />
     </Helmet>
   );

--- a/src/hooks/usePopularFeed.js
+++ b/src/hooks/usePopularFeed.js
@@ -8,7 +8,10 @@ export const usePopularFeed = (pageable) => {
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["popularFeed", pageable],
-    queryFn: () => getPopularFeed(pageable),
+    queryFn: async () => {
+      const result = await getPopularFeed(pageable);
+      return result;
+    },
     keepPreviousData: true,
     select: (incomingData) => {
       if (incomingData === null) {
@@ -23,6 +26,5 @@ export const usePopularFeed = (pageable) => {
     staleTime: 1000 * 60, // 1분 동안 stale 아님
     refetchOnWindowFocus: false,
   });
-
   return { data, isLoading, error };
 };

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -7,12 +7,12 @@ import cate3Img from "../assets/images/cate3Img.png";
 import cate4Img from "../assets/images/cate4Img.png";
 import cate5Img from "../assets/images/cate5Img.png";
 import Background from "../assets/images/background.png";
-import PopularFeed from "../components/home/popularFeed";
-import { usePopularFeed } from "../hooks/usePopularFeed";
+
 import { usePopularRecruit } from "../hooks/usePopularRecruit";
 import { getFirstCategoryNameById } from "../utils/getCategoryById";
 import { calculateDday } from "../utils/getDate";
 import MobileSwiper from "../components/home/mobileSwiper";
+import FeedSwiper from "../components/home/feedSwiper";
 import InfoBox from "../components/home/infoBox";
 import StatisticsSection from "../components/home/StatisticsSection";
 import ContestSection from "../components/home/ContestSection";
@@ -32,8 +32,7 @@ export default function Home() {
   const [searchQuery, setSearchQuery] = useState("");
   const [competitions, setCompetitions] = useState([]);
   const [imageLoadingStates, setImageLoadingStates] = useState({});
-  const [currentFeedPage, setCurrentFeedPage] = useState(1); // 현재 피드 페이지
-  const [isLoadingMore, setIsLoadingMore] = useState(false); // 더보기 로딩 상태
+
   const [showLoginModal, setShowLoginModal] = useState(false);
   const { memberId, roleType } = UserStore();
 
@@ -138,27 +137,6 @@ export default function Home() {
   };
 
   const { data: recruitData } = usePopularRecruit(pageable);
-  const { data: feedData, isLoading: feedLoading } = usePopularFeed(pageable);
-
-  // 현재 페이지에 해당하는 피드 데이터 계산
-  const getCurrentFeedData = () => {
-    // console.log("🔍 getCurrentFeedData에서 feedData:", feedData?.result);
-    if (!feedData?.result) return [];
-    const endIndex = currentFeedPage * 6;
-    return feedData.result.slice(0, endIndex);
-  };
-
-  // 더보기 버튼 클릭 핸들러
-  const handleLoadMoreFeeds = () => {
-    if (currentFeedPage < 3) {
-      setIsLoadingMore(true);
-      // 약간의 지연을 주어 로딩 효과를 보여줌
-      setTimeout(() => {
-        setCurrentFeedPage(prev => prev + 1);
-        setIsLoadingMore(false);
-      }, 300);
-    }
-  };
  
   const handleSearch = (e) => {
     e.preventDefault();
@@ -361,65 +339,16 @@ export default function Home() {
       </div>
 
       {/* 인기 피드 섹션 */}
-      <div className="relative px-6 lg:px-24">
-        <div className="relative items-center  mx-auto px-4 sm:px-6 py-16">
-          <h2 className="text-2xl lg:text-3xl font-bold mb-8">
-            <span className="relative inline-block">
-              <span className="relative z-10">인기있는 피드</span>
+      <div className="relative mt-16 px-">
+        <div className="relative flex flex-col  mx-auto lg:px-6 py-16 overflow-x-hidden">
+        <h2 className="text-3xl font-bold mb-8 px-6 lg:px-24">
+            <span className="relative inline-block ">
+              <span className="relative z-10 ">인기있는 피드</span>
               <div className="absolute bottom-1 left-0 w-full h-3 bg-yellow-300 opacity-60 -z-10"></div>
             </span>
             <span className="ml-2">구경하러 가기</span>
           </h2>
-          {feedLoading ? (
-            <Loading />
-          ) : (
-            <>
-              <div className="grid grid-cols-3 gap-x-4 sm:gap-x-6 md:gap-x-8 gap-y-6 justify-items-center transition-all duration-300 ease-in-out">
-                {getCurrentFeedData().map((profile, index) => (
-                  <PopularFeed
-                    key={`${profile.feedId}-${currentFeedPage}-${index}`}
-                    url={profile.mediaResDto?.fileUrl}
-                    context={profile.categoryName}
-                    username={profile.nickname}
-                    feedId={profile.feedId}
-                    memberId={profile.memberId}
-                  />
-                ))}
-              </div>
-              
-              {/* 더보기 버튼 */}
-              {currentFeedPage < 3 && feedData?.result?.length > currentFeedPage * 6 && (
-                <div className="text-center mt-8">
-                  <button
-                    onClick={handleLoadMoreFeeds}
-                    disabled={isLoadingMore}
-                    className={`px-6 py-3 bg-yellow-point text-white rounded-lg transition-colors duration-200 font-semibold ${
-                      isLoadingMore 
-                        ? 'opacity-50 cursor-not-allowed' 
-                        : 'hover:bg-yellow-600'
-                    }`}
-                  >
-                    {isLoadingMore ? (
-                      <div className="flex items-center gap-2">
-                        <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-                        로딩중...
-                      </div>
-                    ) : (
-                      `더보기`
-                    )}
-                  </button>
-                </div>
-              )}
-              
-              {/* 모든 피드를 로드했을 때 표시 */}
-              {currentFeedPage >= 3 && (
-                <div className="text-center mt-8">
-                  <p className="text-gray-500 text-sm">모든 인기 피드를 확인했습니다!</p>
-                </div>
-              )}
-            </>
-
-          )}
+          <FeedSwiper />
         </div>
       </div>
 


### PR DESCRIPTION

## 🔗 연관된 이슈

> #

## 🛠️ 작업 내용

> 인기 피드를 Swiper Slide로 바꾸고, 인기 피드&공고문 둘 다 navigate 화살표를 추가하여 화살표로도 게시글을 넘길 수 있습니다.

## 📸 스크린샷
인기 피드 수정 전
<img width="1105" height="724" alt="스크린샷 2025-08-01 오후 5 40 38" src="https://github.com/user-attachments/assets/64017f88-db82-436f-aa44-b26a690a7cf6" />


인기 피드 수정 후 
<img width="1131" height="537" alt="스크린샷 2025-08-01 오후 5 41 00" src="https://github.com/user-attachments/assets/d97c4911-609c-4925-831d-5834ac9cdfea" />

인기 공고문 수정 전
<img width="1147" height="408" alt="스크린샷 2025-08-01 오후 5 41 11" src="https://github.com/user-attachments/assets/3866af04-52a6-41e2-9531-33ef9f87ce26" />

인기 공고문 수정 후
<img width="1139" height="393" alt="스크린샷 2025-08-01 오후 5 41 19" src="https://github.com/user-attachments/assets/1547c569-c75a-4c79-a6e6-e4255af98cde" />

