### PR TITLE
FEAT : 모바일 피드 상세페이지 UI 수정

### DIFF
--- a/src/components/studentProfile/postDetail.jsx
+++ b/src/components/studentProfile/postDetail.jsx
@@ -140,11 +140,21 @@ const handleDeleteClick = () => {
             </div>
 
 
-      <div className="flex flex-col rounded-2xl border border-gray-200 p-6 w-full shadow-sm">
+            <div className="flex flex-col rounded-2xl border border-gray-200 p-6 w-full shadow-sm">
+        
+        {/* 모바일: 제목과 날짜  */}
+        <div className="flex justify-between items-center mb-4 lg:hidden">
+          <h2 className="text-base lg:text-xl font-semibold leading-snug text-black">
+            {worksData.topic}
+          </h2>
+          <p className="text-xs lg:text-sm text-gray-500">
+            {getFormattedDate(worksData.lastModifiedTime)}
+          </p>
+        </div>
         
         
-        <div className="flex w-full">
-         <div className="flex w-[65%] h-full relative">
+        <div className="flex flex-col lg:flex-row w-full">
+          <div className="flex w-full lg:w-[65%] h-full relative order-2 lg:order-1">
     <Swiper
       onSwiper={(swiper) => {
         swiperRef.current = swiper;
@@ -203,7 +213,7 @@ const handleDeleteClick = () => {
     )}
   </div>
           
-          <div className="w-full max-w-[35%] pl-6 relative ">
+          <div className="w-full lg:max-w-[35%] lg:pl-6 relative order-1 lg:order-2 mb-6 lg:mb-0">
             {/* 사용자 프로필 정보 */}
         <div className="flex items-center justify-between mb-4 w-full">
           {/* 프로필 사진과 닉네임 (왼쪽) */}
@@ -280,10 +290,10 @@ const handleDeleteClick = () => {
         </div>
             
             
-          <div className="flex flex-col justify-end items-start mb-4 h-[90%] w-full ">
+          <div className="flex flex-col justify-start items-start mb-4 lg:h-[90%] w-full ">
             <div className="w-full h-full flex justify-between flex-col">
               <div className="w-full">
-              <div className="w-full text-xl font-semibold leading-snug text-black py-3 ">
+              <div className="w-full text-xl font-semibold leading-snug text-black py-3 lg:block hidden">
               {worksData.topic}
               </div>
               <div className="w-full text-sm text-gray-600 border-t border-gray-300">
@@ -292,7 +302,7 @@ const handleDeleteClick = () => {
                 </p>
               </div>
               </div>
-              <p className="text-right">{getFormattedDate(worksData.lastModifiedTime)}</p>
+              <p className="text-right mt-4 lg:block hidden">{getFormattedDate(worksData.lastModifiedTime)}</p>
             </div>
             
             </div>

--- a/src/components/studentProfile/postDetail.jsx
+++ b/src/components/studentProfile/postDetail.jsx
@@ -131,7 +131,7 @@ const handleDeleteClick = () => {
         onClick={handleGoBack}
       >
         <img src={backArrow} alt="뒤로가기" className="w-6 h-6 mr-1" />
-        <span>프로필로 돌아가기</span>
+        <span>뒤로가기</span>
       </button>
 
       <p className="text-sm text-gray-500 pr-6">

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -298,7 +298,7 @@ export default function Home() {
         />
 
 {/* 인기 공고문  */}
-      <div className="relative mt-16 px-">
+      <div className="relative mt-16 px-6 lg:px-24">
         <div className="relative flex flex-col  mx-auto lg:px-6 py-16 overflow-x-hidden">
         <h2 className="text-2xl lg:text-3xl font-bold mb-8 px-6 lg:px-24">
             <span className="relative inline-block ">
@@ -312,7 +312,7 @@ export default function Home() {
       </div>
 
       {/* 인기 피드 섹션 */}
-      <div className="relative mt-16 px-">
+      <div className="relative lg:mt-16 px-6 lg:px-24">
         <div className="relative flex flex-col  mx-auto lg:px-6 py-16 overflow-x-hidden">
         <h2 className="text-2xl lg:text-3xl font-bold mb-8 px-6 lg:px-24">
             <span className="relative inline-block ">


### PR DESCRIPTION

## 🛠️ 작업 내용

> 화면이 작은 모바일에서 피드 상세 내용이 읽기 어려워 `feed.jsx`와 같게 바꾸었습니다. 

## 📸 스크린샷

왼쪽 = 수정 전, 오른쪽 = 수정 후

<img width="265" height="584" alt="스크린샷 2025-08-04 오후 5 22 56" src="https://github.com/user-attachments/assets/aa5ca56d-1603-4f95-afb4-ab9f5555c837" />
<img width="272" height="597" alt="스크린샷 2025-08-04 오후 5 23 25" src="https://github.com/user-attachments/assets/f3a5260b-2858-4894-b377-091ce135c5b4" />

## 💬 리뷰 요구사항

> 



