### PR TITLE
FEAT : 프로필 리스트, 공고문 모아보기 피드 조회

### DIFF
--- a/src/components/studentProfile/profile.jsx
+++ b/src/components/studentProfile/profile.jsx
@@ -12,7 +12,7 @@ export default function Profile({
   temperature,
   userName,
   userDetail,
-  userWorks,
+  popularFeeds,
 }) {
   // console.log("profileImageUrl", profileImageUrl);
   const navigate = useNavigate();
@@ -56,24 +56,33 @@ export default function Profile({
       className="flex relative flex-col items-center justify-center w-full border border-[#D4D4D4] rounded-[30px] p-8 gap-2 cursor-pointer hover:shadow-md transition-all"
     >
       <img className="absolute top-4 right-4 w-11 z-10" src={sendIco} onClick={() => handleChat(memberId)} />
-      <div onClick={() => clickHandler(memberId)}>
+      <div className="flex flex-col items-center justify-center"
+      onClick={() => clickHandler(memberId)}>
       <img 
         src={profileImageUrl || getDefaultImage()} 
-        className="rounded-full" 
+        className="rounded-full w-24 h-24 border border-gray-200 " 
         alt={userName || "프로필 이미지"}
         onError={(e) => {
           e.target.src = getDefaultImage();
         }}
       />
       {/* <div className="font-semibold text-[15px]">스프 온도 {temperature}도</div> */}
-      <div className="font-semibold text-sm lg:text-[15px] mt-4 text-gray-500">스프 온도 36.5도</div>
+      <div className="font-semibold text-sm lg:text-[14px] mt-2 text-gray-500">스프 온도 36.5도</div>
       <div className="flex flex-col justify-center">
-        <div className="font-semibold text-base lg:text-2xl">{userName}</div>
+        <div className="font-semibold text-base lg:text-2xl my-2">{userName}</div>
         <div className="text-[#5B5B5B]">{userDetail}</div>
       </div>
-      <div className="grid grid-cols-3 justify-center gap-2">
-        {userWorks?.map((data) => (
-          <img key={i} src={data} />
+      <div className="grid grid-cols-3  justify-center gap-2">
+        {popularFeeds?.map((feed, index) => (
+          <img 
+            key={index} 
+            src={`${import.meta.env.VITE_S3_BUCKET_URL}${feed.imageUrl}`}
+            alt={`피드 이미지 ${index + 1}`}
+            className="w-32 h-32 object-cover rounded-lg"
+            onError={(e) => {
+              e.target.style.display = 'none';
+            }}
+          />
         ))}
       </div>
       </div>

--- a/src/pages/recruit.jsx
+++ b/src/pages/recruit.jsx
@@ -78,11 +78,11 @@ export default function Recruit() {
        
       });
 
-      console.log("API 응답:", response);
+      // console.log("API 응답:", response);
 
       if (response.data) {
         const recruits = response.data.result?.content || [];
-        console.log("공고문 데이터:", recruits);
+        // console.log("공고문 데이터:", recruits);
        
         setFilteredRecruits(recruits);
 
@@ -245,7 +245,7 @@ useEffect(() => {
 
   // selectedCategory나 currentPage가 변경될 때 실행
   useEffect(() => {
-    console.log("useEffect 실행 - selectedCategory:", selectedCategory, "currentPage:", currentPage);
+    // console.log("useEffect 실행 - selectedCategory:", selectedCategory, "currentPage:", currentPage);
     fetchRecruits();
   }, [selectedCategory, currentPage, fetchRecruits]);
 

--- a/src/pages/studentProfileList.jsx
+++ b/src/pages/studentProfileList.jsx
@@ -66,7 +66,7 @@ export default function StudentProfileList({secondCategoryId, thirdCategoryId ,k
                 temperature={data.temperature}
                 userName={data.nickname}
                 userDetail={data.userDetail}
-                userWorks={data.userWorks}
+                popularFeeds={data.popularFeeds}
               />
             ))}
           </div>


### PR DESCRIPTION

## 🛠️ 작업 내용

> 프로필 리스트, 공고문 모아보기에 학생 프로필을 조회할 때 피드를 같이 조회합니다.
프로필 리스트-3개, 공고문 모아보기 -2개씩 학생별 피드를 조회.

## 📸 스크린샷
대학생 프로필 리스트
<img width="1680" height="964" alt="스크린샷 2025-08-05 오전 11 51 23" src="https://github.com/user-attachments/assets/abe37537-f770-4f7b-8fbe-e7be15d5661d" />


공고문 모아보기 페이지 
<img width="1680" height="964" alt="스크린샷 2025-08-05 오전 11 51 06" src="https://github.com/user-attachments/assets/68a4f1f6-7529-4ebc-95d2-d414fa1681be" />



