### PR TITLE
FEAT : 댓글. 대댓글 기능 추가

### DIFF
--- a/src/api/additionalFeed.js
+++ b/src/api/additionalFeed.js
@@ -1,0 +1,85 @@
+import axios from "axios";
+import client from "./client";
+
+export const patchLike = async (feedId) => {
+    try {
+      const response = await client.patch(`/api/v1/feed/${feedId}/like`, {
+       
+      });
+      return response.data;
+    } catch (error) {
+      console.error("좋아요 생성/삭제 에러:", error);
+      throw error;
+    }
+  };
+  
+export const getComment = async (postId) => {
+    try {
+      const response = await client.get(`/api/v1/post/${postId}/comment`, {
+       
+      });
+      return response.data;
+    } catch (error) {
+      console.error("댓글 조회 에러:", error);
+      throw error;
+    }
+  };
+
+  export const postComment = async (postId, requestBody) => {
+    try {
+      const response = await client.post(`/api/v1/post/${postId}/comment`, requestBody);
+      return response.data;
+    } catch (error) {
+      console.error("댓글 생성 에러:", error);
+      throw error;
+    }
+  };
+
+  export const deleteComment = async (postId, requestBody) => {
+    try {
+      const response = await client.delete(`/api/v1/post/${postId}/comment`, requestBody);
+      return response.data;
+    } catch (error) {
+      console.error("댓글 삭제 에러:", error);
+      throw error;
+    }
+  };
+
+  // export const patchComment = async (postId) => {
+  //   try {
+  //     const response = await client.patch(`/api/v1/post/${postId}/comment`, {
+       
+  //     });
+  //     return response.data;
+  //   } catch (error) {
+  //     console.error("댓글 수정 에러:", error);
+  //     throw error;
+  //   }
+  // };
+
+  // 대댓글 작성
+  export const postAdditionalComment = async (postId, requestBody) => {
+    try {
+      const response = await client.post(`/api/v1/post/${postId}/comment/reply`, requestBody);
+      return response.data;
+    } catch (error) {
+      console.error("대댓글 생성 에러:", error);
+      throw error;
+    }
+  };
+
+  // 대댓글 조회
+  export const getAdditionalComment = async (postId, commentId, pageable) => {
+    try {
+      const response = await client.get(`/api/v1/post/${postId}/comment/${commentId}/reply`, {
+        params: {
+          page: pageable.page,
+          size: pageable.size,
+        },
+      });
+      return response.data;
+    } catch (error) {
+      console.error("대댓글 조회 에러:", error);
+      throw error;
+    }
+  };

--- a/src/components/home/StatisticsSection.jsx
+++ b/src/components/home/StatisticsSection.jsx
@@ -33,14 +33,14 @@ export default function StatisticsSection({ viewCount, userCount, recruitCount }
         <div className="hidden lg:flex flex-col sm:flex-row gap-1 sm:gap-2 lg:ml-auto items-center">
           <div className="text-2xl sm:text-3xl lg:text-5xl font-bold">대학생 프리랜서 가입자: </div>
           <div className="text-2xl sm:text-3xl lg:text-5xl font-bold">
-            +{animatedUserCount.toLocaleString()}
+            +{(animatedUserCount+102).toLocaleString()}
           </div>
         </div>
         {/* Mobile 대학생 프리랜서 가입자*/}
         <div className="lg:hidden flex justify-between sm:flex-row gap-1 sm:gap-2 lg:ml-auto items-center">
           <div className="text-2xl sm:text-3xl lg:text-5xl font-bold">대학생 프리랜서 가입자: </div>
           <div className="text-2xl sm:text-3xl lg:text-5xl font-bold">
-            +{animatedUserCount.toLocaleString()}
+            +{(animatedUserCount+102).toLocaleString()}
           </div>
         </div>
         {/* PC 등록된 기업 공고문*/}

--- a/src/components/post/comment.jsx
+++ b/src/components/post/comment.jsx
@@ -1,20 +1,149 @@
-export default function Comment() {
+import { useState, useEffect } from "react";
+import BasicProfileImg4 from "../../assets/images/BasicProfileImg4.png";
+import editIco from "../../assets/images/editIco.svg";
+import trashIco from "../../assets/images/trashIco.svg";
+import { UserStore } from "../../store/userStore";
+import { deleteComment, postAdditionalComment } from "../../api/additionalFeed";
+import { useParams } from "react-router-dom";
+import AlertModal from "../../components/alertModal";
+
+export default function Comment({ comment, onReplyClick, onToggleReplies, showReplies, hasReplies, checkHasReplies }) {
+    const [editContent, setEditContent] = useState("");
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+    const [hasRepliesState, setHasRepliesState] = useState(false);
+    const { id, worksId } = useParams();
+    const { memberId } = UserStore();
+    
+    const formatDate = (dateString) => {
+        const date = new Date(dateString);
+        const year = date.getFullYear().toString().slice(-2); // 마지막 2자리
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        
+        return `${year}.${month}.${day} ${hours}:${minutes}`;
+    };
+
+    // 컴포넌트 마운트 시 대댓글 존재 여부 확인
+    useEffect(() => {
+        const checkReplies = async () => {
+            if (checkHasReplies) {
+                const hasReplies = await checkHasReplies();
+                setHasRepliesState(hasReplies);
+            }
+        };
+        checkReplies();
+    }, [checkHasReplies]);
+    
+    // console.log(comment);
+    // console.log("worksId from URL:", worksId);
+    
+    const handleDeleteComment = async () => {
+        const requestBody = {
+            commentId: comment.commentId,
+            writerId: memberId,
+            content: comment.content
+        };
+        
+        console.log("=== 삭제 API 호출 정보 ===");
+        console.log("worksId (postId):", worksId);
+        console.log("requestBody:", requestBody);
+        console.log("comment 객체:", comment);
+        console.log("memberId:", memberId);
+        console.log("==========================");
+        
+        try {
+            const response = await deleteComment(worksId, requestBody);
+            console.log("삭제 API 응답:", response);
+            // 삭제 성공 후 페이지 새로고침 또는 댓글 목록 업데이트
+            window.location.reload();
+        } catch (error) {
+            console.error("댓글 삭제 에러:", error);
+        }
+    };
+
+    const handleDeleteClick = () => {
+        console.log("=== 삭제 버튼 클릭됨 ===");
+        console.log("showDeleteModal 상태:", showDeleteModal);
+        setShowDeleteModal(true);
+    };
+
+    const handleConfirmDelete = () => {
+        console.log("=== 확인 버튼 클릭됨 ===");
+        handleDeleteComment();
+        setShowDeleteModal(false);
+    };
+
+    const handleCancelDelete = () => {
+        setShowDeleteModal(false);
+    };
+
+    const handleReplyClick = () => {
+        if (onReplyClick) {
+            onReplyClick(comment);
+        }
+    };
+
+    const handleToggleRepliesClick = () => {
+        if (onToggleReplies) {
+            onToggleReplies();
+        }
+    };
+
     return (
         <div>
-           <div className="flex items-center gap-4">
-            <div className="w-12 h-12 rounded-full bg-gray-200"></div>
+           <div className="flex items-center gap-4 justify-between">
+            <div className="flex items-center gap-4">
+            <div className="w-12 h-12 rounded-full border-[0.5px] border-gray-200">
+                {comment.profileUrl ? (
+                    <img src={comment.profileUrl} alt="profile" className="w-full h-full rounded-full" />
+                ) : (
+                    <img src={BasicProfileImg4} alt="profile" className="w-full h-full rounded-full" />
+                )}
+            </div>
             <div className="flex flex-col gap-1">
                 <div className="flex items-center gap-2">
-                <p className="text-sm font-medium">John Doe</p>
-                <p className="text-sm text-gray-400">2025-01-01</p>
+                <p className="text-sm font-medium">{comment.nickname}</p>
+                <p className="text-sm text-gray-400">{formatDate(comment.lastModifiedTime)}</p>
                 </div>
-                <p className="text-medium text-gray-800 font-medium">댓글 내용입니다.</p>
-                <div className="text-sm text-gray-400 flex items-center gap-2">
-                    <button>답글 달기</button>
-                    <button>답글 열기</button>
-                </div>
+                <p className="text-medium text-gray-800 font-medium">{comment.content}</p>
+                
+                {!comment.parentId && (
+                    <div className="text-sm text-gray-400 flex items-center gap-2">
+                        <button onClick={handleReplyClick}>답글 달기</button>
+                        {hasRepliesState && (
+                            <button onClick={handleToggleRepliesClick}>
+                                {showReplies ? "답글 닫기" : "답글 열기"}
+                            </button>
+                        )}
+                    </div>
+                )}
             </div>
+            </div>
+            {memberId === comment.writerId? ( 
+                <div className="flex gap-2 opacity-50">
+                <button 
+                onClick={handleDeleteClick}
+                className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center">
+                    <img src={trashIco} alt="trashIco" className="w-4 h-4" />
+                </button>
+            </div>) : (
+                <></>
+            )}
+           
            </div>
+           
+           {showDeleteModal && (
+               <AlertModal
+                   type="warning"
+                   title="댓글을 삭제하시겠습니까?"
+                   TrueBtnText="확인"
+                   FalseBtnText="취소"
+                   onClickTrue={handleConfirmDelete}
+                   onClickFalse={handleCancelDelete}
+               />
+           )}
         </div>
     )
 }

--- a/src/components/post/commentList.jsx
+++ b/src/components/post/commentList.jsx
@@ -1,13 +1,209 @@
 import Comment from "./comment";
+import ReplyComment from "./replyComment";
 import sendIco from "../../assets/images/sendIco.svg";
+import { useState, useEffect } from "react";
+import { getComment, postComment, deleteComment, postAdditionalComment, getAdditionalComment } from "../../api/additionalFeed";
+import { UserStore } from "../../store/userStore";
+import { useParams } from "react-router-dom";
+import BasicProfileImg4 from "../../assets/images/BasicProfileImg4.png";
 
 export default function commentList() {
+    const [commentList, setCommentList] = useState([]);
+    const [replyComments, setReplyComments] = useState({}); // { commentId: [replies] }
+    const [showReplies, setShowReplies] = useState({}); // { commentId: boolean }
+    const [commentContent, setCommentContent] = useState("");
+    const [replyMode, setReplyMode] = useState(false);
+    const [replyToComment, setReplyToComment] = useState(null);
+    const { id, worksId } = useParams();
+    const { memberId } = UserStore();
+
+    const fetchComments = async () => {
+        try {
+            const response = await getComment(worksId);
+            // console.log("댓글 리스트 조회 결과:", response);
+            if (response?.result?.content) {
+                setCommentList(response.result.content);
+                // console.log("댓글 리스트:", response.result.content);
+            }
+        } catch (error) {
+            console.error("댓글 조회 에러:", error);
+        }
+    };
+
+    useEffect(() => {
+        fetchComments();
+    }, [worksId]);
+
+    const fetchAdditionalComments = async (commentId) => {
+        try {
+            const response = await getAdditionalComment(worksId, commentId, { page: 0, size: 10 });
+            console.log(`댓글 ID ${commentId}의 대댓글 리스트:`, response);
+            
+            if (response?.result?.content && response.result.content.length > 0) {
+                setReplyComments(prev => ({
+                    ...prev,
+                    [commentId]: response.result.content
+                }));
+            }
+        } catch (error) {
+            console.error("대댓글 조회 에러:", error);
+        }
+    };
+
+    const handleCommentSubmit = async () => {
+        if (!commentContent.trim()) return;
+
+        try {
+            if (replyMode) {
+                // 답글 작성
+                const requestBody = {
+                    writerId: memberId,
+                    content: commentContent,
+                    authorId: Number(id),
+                    parentId: replyToComment.commentId
+                };
+
+                await postAdditionalComment(worksId, requestBody);
+            } else {
+                // 일반 댓글 작성
+                const requestBody = {
+                    writerId: memberId,
+                    content: commentContent,
+                    authorId: Number(id)
+                };
+
+                await postComment(worksId, requestBody);
+            }
+
+            setCommentContent("");
+            setReplyMode(false);
+            setReplyToComment(null);
+
+            fetchComments();
+        } catch (error) {
+            console.error("댓글 작성 에러:", error);
+        }
+    };
+
+    const handleKeyPress = (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            handleCommentSubmit();
+        }
+    };
+
+    const handleReplyClick = (comment) => {
+        setReplyMode(true);
+        setReplyToComment(comment);
+    };
+
+    const handleCancelReply = () => {
+        setReplyMode(false);
+        setReplyToComment(null);
+        setCommentContent("");
+    };
+
+    const handleReplyDelete = async (replyComment) => {
+        try {
+            const requestBody = {
+                commentId: replyComment.commentId,
+                writerId: memberId,
+                content: replyComment.content
+            };
+            
+            await deleteComment(worksId, requestBody);
+            fetchComments(); // 댓글 목록 새로고침
+        } catch (error) {
+            console.error("대댓글 삭제 에러:", error);
+        }
+    };
+
+    const handleToggleReplies = async (commentId) => {
+        const isCurrentlyShown = showReplies[commentId];
+        
+        if (!isCurrentlyShown) {
+            // 답글 열기: API 호출 후 표시
+            await fetchAdditionalComments(commentId);
+        }
+        
+        setShowReplies(prev => ({
+            ...prev,
+            [commentId]: !isCurrentlyShown
+        }));
+    };
+
+    const checkHasReplies = async (commentId) => {
+        try {
+            const response = await getAdditionalComment(worksId, commentId, { page: 0, size: 1 });
+            return response?.result?.content && response.result.content.length > 0;
+        } catch (error) {
+            console.error("대댓글 확인 에러:", error);
+            return false;
+        }
+    };
+
     return (
         <div className="flex flex-col rounded-2xl border border-gray-200 px-6 py-6 w-full shadow-sm max-w-4xl mx-auto mt-4 mb-24">
-            <Comment />
+            {/* 댓글 목록 */}
+            <div className="flex flex-col gap-4">
+                {commentList?.length > 0 ? (
+                    commentList?.map((comment) => (
+                        <div key={comment.commentId}>
+                            <Comment 
+                                comment={comment} 
+                                onReplyClick={handleReplyClick}
+                                onToggleReplies={() => handleToggleReplies(comment.commentId)}
+                                showReplies={showReplies[comment.commentId]}
+                                hasReplies={replyComments[comment.commentId]?.length > 0}
+                                checkHasReplies={() => checkHasReplies(comment.commentId)}
+                            />
+                            {/* 대댓글 표시 */}
+                            {showReplies[comment.commentId] && replyComments[comment.commentId] && (
+                                <div className="ml-8 mt-2 space-y-2">
+                                    {replyComments[comment.commentId].map((reply) => (
+                                        <ReplyComment 
+                                            key={reply.commentId} 
+                                            reply={reply} 
+                                            onDelete={handleReplyDelete}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    ))
+                ) : (
+                    <div className="py-4" />
+                )}
+            </div>
+
+            {/* 답글 모드 표시 */}
+            {replyMode && replyToComment && (
+                <div className="flex items-center gap-2 mt-4 p-3 bg-yellow-50 rounded-lg">
+                    <span className="text-sm text-gray-600">
+                        {replyToComment.nickname} 님께 답글 작성...
+                    </span>
+                    <button 
+                        onClick={handleCancelReply}
+                        className="text-sm text-gray-400 hover:text-gray-600"
+                    >
+                        취소
+                    </button>
+                </div>
+            )}
+
+            {/* 댓글 입력칸 */}
             <div className="flex items-center gap-2 mt-4">
-                <input className="w-full h-10 rounded-full border border-gray-200 px-4 py-2 transition-all duration-200 focus:outline-none focus:shadow-sm" placeholder="댓글을 입력해주세요."></input>
-                <button className="w-16 h-10 rounded-full bg-yellow-point flex items-center justify-center">
+                <input 
+                    className="w-full h-10 rounded-full border border-gray-200 px-4 py-2 transition-all duration-200 focus:outline-none focus:shadow-sm focus:ring-2 focus:ring-yellow-point focus:border-transparent" 
+                    placeholder={replyMode ? "답글을 입력해주세요." : "댓글을 입력해주세요."}
+                    value={commentContent}
+                    onChange={(e) => setCommentContent(e.target.value)}
+                    onKeyPress={handleKeyPress}
+                />
+                <button 
+                    className="w-16 h-10 rounded-full bg-yellow-point flex items-center justify-center"
+                    onClick={handleCommentSubmit}
+                >
                     <img src={sendIco} alt="sendIco" className="w-10 h-10" />
                 </button>
             </div>

--- a/src/components/post/replyComment.jsx
+++ b/src/components/post/replyComment.jsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import BasicProfileImg4 from "../../assets/images/BasicProfileImg4.png";
+import trashIco from "../../assets/images/trashIco.svg";
+import { UserStore } from "../../store/userStore";
+import AlertModal from "../../components/alertModal";
+
+export default function ReplyComment({ reply, onDelete }) {
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+    const { memberId } = UserStore();
+
+    const formatDate = (dateString) => {
+        const date = new Date(dateString);
+        const year = date.getFullYear().toString().slice(-2); // 마지막 2자리
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        
+        return `${year}.${month}.${day} ${hours}:${minutes}`;
+    };
+
+    const handleDeleteClick = () => {
+        setShowDeleteModal(true);
+    };
+
+    const handleConfirmDelete = () => {
+        onDelete(reply);
+        setShowDeleteModal(false);
+    };
+
+    const handleCancelDelete = () => {
+        setShowDeleteModal(false);
+    };
+
+    return (
+        <div className="flex items-start gap-3 rounded-lg py-2">
+            <div className="w-8 h-8 rounded-full border-[0.5px] border-gray-200 flex-shrink-0">
+                {reply.profileUrl ? (
+                    <img src={reply.profileUrl} alt="profile" className="w-full h-full rounded-full" />
+                ) : (
+                    <img src={BasicProfileImg4} alt="profile" className="w-full h-full rounded-full" />
+                )}
+            </div>
+            <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                    <p className="text-sm font-medium">{reply.nickname}</p>
+                    <p className="text-xs text-gray-400">{formatDate(reply.lastModifiedTime)}</p>
+                </div>
+                <p className="text-sm text-gray-800">{reply.content}</p>
+            </div>
+            {memberId === reply.writerId && (
+                <div className="flex opacity-50">
+                    <button 
+                        onClick={handleDeleteClick}
+                        className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center"
+                    >
+                        <img src={trashIco} alt="trashIco" className="w-4 h-4" />
+                    </button>
+                </div>
+            )}
+            
+            {showDeleteModal && (
+                <AlertModal
+                    type="warning"
+                    title="답글을 삭제하시겠습니까?"
+                    TrueBtnText="확인"
+                    FalseBtnText="취소"
+                    onClickTrue={handleConfirmDelete}
+                    onClickFalse={handleCancelDelete}
+                />
+            )}
+        </div>
+    );
+} 

--- a/src/pages/postUpload.jsx
+++ b/src/pages/postUpload.jsx
@@ -282,8 +282,8 @@ export default function PostUpload() {
   };
 
   return (
-    <div className="max-w-[1000px] mx-auto my-10">
-      <div className="w-[1000px] border-2 flex flex-col justify-center items-left p-10 gap-4">
+    <div className="lg:max-w-5xl mx-auto my-10">
+      <div className="lg:w-[1000px] border-2 flex flex-col justify-center items-left p-10 gap-4">
         <div className="text-center font-bold text-3xl">게시물 작성</div>
         <PostInput
           title="제목"

--- a/src/pages/recruitUpload.jsx
+++ b/src/pages/recruitUpload.jsx
@@ -391,9 +391,9 @@ dtoList.forEach((dto, i) => {
   const thirdCategories = thirdCategoryData.third_category || [];
 
   return (
-    <div className="pt-24 px-6 w-1/2 max-w-5xl mx-auto mb-12">
-      <h1 className="text-3xl font-bold w-1/4 mx-auto">
-        {isEditMode ? '공고문 수정' : '공고문 작성'}
+    <div className="pt-24 px-6 w-full lg:w-1/2  lg:max-w-5xl mx-auto mb-12">
+      <h1 className="text-3xl font-bold w-1/4 mx-auto whitespace-nowrap">
+        {isEditMode ? '공고문 수정' :   '공고문 작성'}
       </h1>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div>


### PR DESCRIPTION


## 🛠️ 작업 내용

> 피드에 댓글, 대댓글 기능을 추가하였습니다.
본인이 작성했을 시, 삭제가 가능하게 버튼을 두었고 수정 기능은 없앴습니다.
답글 달기 버튼을 누르면 아래 input에 해당 댓글에 대한 대댓글을 달 수 있고, 대댓글이 있는 경우 답글 열기 버튼을 통해 조회할 수 있습니다.

## 📸 스크린샷
<img width="530" height="329" alt="image" src="https://github.com/user-attachments/assets/906e4fa4-aae7-4ff7-8923-c9d99a319252" />
## 💬 리뷰 요구사항

> 댓글 , 대댓글 조회를 페이징 처리 해야합니다.
댓글은 슬라이싱, 대댓글은 페이지



