### PR TITLE
FIX : 개발 카테고리(6) 카테고리 메뉴 필터링

### DIFF
--- a/src/components/categoryMenu.jsx
+++ b/src/components/categoryMenu.jsx
@@ -41,14 +41,10 @@ const DesktopCategoryMenu = () => (
       return (
         <div key={second.second_category_id} className="mb-3">
           <div 
-            className={`font-semibold text-sm lg:text-base flex items-center justify-between p-2 rounded text-gray-700 transition-colors ${
+            className={`font-semibold text-sm lg:text-base flex items-center justify-between p-2 rounded cursor-pointer transition-colors ${
               second.first_category_id === 6 
-                ? 'cursor-pointer hover:text-yellow-point hover:bg-yellow-50' 
-                : 'cursor-pointer hover:text-yellow-point hover:bg-yellow-50'
-            } ${
-              isSelectedSecond || (second.first_category_id === 6 && isSelectedFirst)
-                ? 'bg-yellow-50 text-yellow-point'
-                : ''
+                ? (isSelectedSecond ? 'bg-yellow-50 text-yellow-point' : 'text-gray-600 hover:text-yellow-point hover:bg-yellow-50')
+                : (isSelectedSecond ? 'bg-yellow-50 text-yellow-point' : 'text-gray-700 hover:text-yellow-point hover:bg-yellow-50')
             }`}
             onClick={second.first_category_id === 6 ? () => handleSecondCategoryClick(second) : undefined}
           >
@@ -89,7 +85,6 @@ const DesktopCategoryMenu = () => (
     const [selectedSecondCategory, setSelectedSecondCategory] = useState(null);
 
     const handleSecondCategoryClick = (second) => {
-      // 대분류가 6(IT.개발)인 경우 중분류를 직접 클릭
       if (second.first_category_id === 6) {
         handleSecondCategoryClick(second);
         return;

--- a/src/pages/studentFeedList.jsx
+++ b/src/pages/studentFeedList.jsx
@@ -42,14 +42,29 @@ const {
         const data = await getFeed(categoryParam, secondCategoryId, thirdCategoryId, keyword, pageable);
         // console.log("getFeed 결과:", data);
         
-        if (data?.result?.content && thirdCategoryId) {
-          const filteredContent = data.result.content.filter(feed => {
-            const feedCategories = feed.categoryDtos || [];
-            
-            return feedCategories.some(category => 
-              category.thirdCategory === thirdCategoryId
-            );
-          });
+        if (data?.result?.content) {
+          let filteredContent = data.result.content;
+          
+          // 대분류가 6인 경우 중분류로 필터링
+          if (categoryParam === "6" && secondCategoryId) {
+            filteredContent = data.result.content.filter(feed => {
+              const feedCategories = feed.categoryDtos || [];
+              
+              return feedCategories.some(category => 
+                category.secondCategory === secondCategoryId
+              );
+            });
+          }
+          // 대분류가 6이 아닌경우 선탯한 소분류로 필터링
+          else if (thirdCategoryId) {
+            filteredContent = data.result.content.filter(feed => {
+              const feedCategories = feed.categoryDtos || [];
+              
+              return feedCategories.some(category => 
+                category.thirdCategory === thirdCategoryId
+              );
+            });
+          }
           
           return {
             ...data,


### PR DESCRIPTION

## 🛠️ 작업 내용

> IT · 개발 카테고리는 소분류가 없어 기존 카테고리 메뉴를 그대로 재사용할 수 없는 문제. 카테고리 메뉴박스로 필터링 하기 위해 수정했습니다.

피드 리스트에서 대분류 인덱스가 6인 경우와 아닌경우를 나누고, 인덱스가 6인 경우는 스타일을 다르게 적용하여 이제 사용자가 IT · 개발 카테고리에서도 필터링을 할 수 있습니다.
```
if (data?.result?.content) {
          let filteredContent = data.result.content;
          
          // 대분류가 6인 경우 중분류로 필터링
          if (categoryParam === "6" && secondCategoryId) {
            filteredContent = data.result.content.filter(feed => {
              const feedCategories = feed.categoryDtos || [];
              
              return feedCategories.some(category => 
                category.secondCategory === secondCategoryId
              );
            });
          }
          // 대분류가 6이 아닌경우 선탯한 소분류로 필터링
          else if (thirdCategoryId) {
            filteredContent = data.result.content.filter(feed => {
              const feedCategories = feed.categoryDtos || [];
              
              return feedCategories.some(category => 
                category.thirdCategory === thirdCategoryId
              );
            });
          }
```




## 📸 스크린샷
수정 전
<img width="490" height="280" alt="image" src="https://github.com/user-attachments/assets/ef668402-7e5d-49cd-b5ae-110cc0ee763d" />


수정 후
<img width="483" height="283" alt="image" src="https://github.com/user-attachments/assets/50052b9d-1cd3-4b1a-bd48-ef427f0f6265" />


