### PR TITLE
FIX : 카카오 로그인 프로필 이미지 추가

### DIFF
--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -47,7 +47,7 @@ export default function Login() {
   // 카카오 로그인
   const REST_API_KEY = import.meta.env.VITE_REST_API_KEY;
   const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI;
-  const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=profile_nickname,account_email`;
+  const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=profile_nickname,account_email,profile_image`;
   
   const handleKakaoLogin = () => {
     localStorage.setItem('socialProvider', 'KAKAO');


### PR DESCRIPTION

## 🛠️ 작업 내용

> 소셜 로그인 - 카카오에서 요청 값으로 프로필 이미지 정보를 추가했습니다.

```
const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=profile_nickname,account_email,profile_image`;
```
카카오 API 에서 필수 값으로 이름, 이메일, 프로필 이미지를 설정했기 때문에 프로필 이미지를 추가했습니다.



