### PR TITLE
FEAT : 로그아웃 시 리프레시 토큰 삭제 & 프로필 UI 수정

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -106,6 +106,9 @@ useEffect(() => {
     }
     setShowMobileMenu(false);
   };
+  const deleteCookie = (name) => {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+  };
 
   const toggleLogin = () => {
     UserStore.getState().clearUser();
@@ -115,6 +118,9 @@ useEffect(() => {
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
     localStorage.removeItem("user-storage");
+
+  deleteCookie("refreshToken");
+
 
     setIsLogin(false);
     setShowUserMenu(false);

--- a/src/components/studentProfile/profile.jsx
+++ b/src/components/studentProfile/profile.jsx
@@ -73,7 +73,7 @@ export default function Profile({
         <div className="text-[#5B5B5B]">{userDetail}</div>
       </div>
       <div className="grid grid-cols-3  justify-center gap-2">
-        {popularFeeds?.map((feed, index) => (
+        {popularFeeds ? (popularFeeds?.map((feed, index) => (
           <img 
             key={index} 
             src={`${import.meta.env.VITE_S3_BUCKET_URL}${feed.imageUrl}`}
@@ -83,7 +83,13 @@ export default function Profile({
               e.target.style.display = 'none';
             }}
           />
-        ))}
+        ))) : (
+          <>
+            <div className="w-32 h-32 bg-gray-200 rounded-lg border border-gray-300"></div>
+            <div className="w-32 h-32 bg-gray-200 rounded-lg border border-gray-300"></div>
+            <div className="w-32 h-32 bg-gray-200 rounded-lg border border-gray-300"></div>
+          </>
+        )}
       </div>
       </div>
       

--- a/src/components/studentProfile/profile.jsx
+++ b/src/components/studentProfile/profile.jsx
@@ -14,7 +14,7 @@ export default function Profile({
   userDetail,
   popularFeeds,
 }) {
-  // console.log("profileImageUrl", profileImageUrl);
+
   const navigate = useNavigate();
   const [showLoginModal, setShowLoginModal] = useState(false);
   const { memberId: currentMemberId } = UserStore();
@@ -73,7 +73,7 @@ export default function Profile({
         <div className="text-[#5B5B5B]">{userDetail}</div>
       </div>
       <div className="grid grid-cols-3  justify-center gap-2">
-        {popularFeeds ? (popularFeeds?.map((feed, index) => (
+        {popularFeeds && popularFeeds.length > 0 ? (popularFeeds?.map((feed, index) => (
           <img 
             key={index} 
             src={`${import.meta.env.VITE_S3_BUCKET_URL}${feed.imageUrl}`}
@@ -85,9 +85,9 @@ export default function Profile({
           />
         ))) : (
           <>
-            <div className="w-32 h-32 bg-gray-200 rounded-lg border border-gray-300"></div>
-            <div className="w-32 h-32 bg-gray-200 rounded-lg border border-gray-300"></div>
-            <div className="w-32 h-32 bg-gray-200 rounded-lg border border-gray-300"></div>
+            <div className="w-16 h-32 bg-gray-100 rounded-lg border border-gray-200"></div>
+            <div className="w-16 h-32 bg-gray-100 rounded-lg border border-gray-200"></div>
+            <div className="w-16 h-32 bg-gray-100 rounded-lg border border-gray-200"></div>
           </>
         )}
       </div>

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -35,7 +35,8 @@ export default function Login() {
       UserStore.getState().setAccessToken(result.accessToken);
       localStorage.setItem("accessToken", result.accessToken);
   
-      navigate("/");
+      // navigate("/");
+      console.log(response)
     },
   
     onError: (error) => {


### PR DESCRIPTION

## 🛠️ 작업 내용

> 로그아웃 시 리프레시 토큰 삭제 & 피드 UI 수정

로그아웃시 리프레시 토큰을 같이 삭제하게 추가하였습니다.
피드가 없는 프로필과 피드가 있는 프로필이 동일한 UI를 가지도록 피드가 없는 프로필에 빈 div를 추가하였습니다.

## 📸 스크린샷
<img width="331" height="218" alt="image" src="https://github.com/user-attachments/assets/163eade0-24c5-4fe6-97c8-355e953fcf00" />





