### PR TITLE
FEAT : 로그인 관련 UI 수정 및 가입된 계정 카카오 로그인 연동

### DIFF
--- a/src/api/member.js
+++ b/src/api/member.js
@@ -62,22 +62,22 @@ export async function postEmailVerify(email, code, purpose) {
 
       }
     );
-    console.log("✅ 응답 성공:", response);
+  
     return response.data;
   } catch (error) {
-    console.error("❌ 요청 실패:", error);
+    console.error("요청 실패:", error);
     if (error.response) {
-      console.error("📡 서버 응답 에러:", {
+      console.error("서버 응답 에러:", {
         status: error.response.status,
         data: error.response.data,
         headers: error.response.headers,
       });
     } else if (error.request) {
-      console.error("📭 요청은 보내졌지만 응답 없음:", error.request);
+      console.error("응답 없음:", error.request);
     } else {
-      console.error("🚨 요청 설정 중 에러:", error.message);
+      console.error("요청 설정 중 에러:", error.message);
     }
-    throw error; // 다시 던져서 useMutation onError로 보내기
+    throw error; 
   }
 
 }

--- a/src/api/social.js
+++ b/src/api/social.js
@@ -22,3 +22,13 @@ export const postSocialSignUp = async (requestBody) => {
   }
 };
 
+// 이미 가입된 게정 - 마이페이지 연동
+export const postSocialLoginLink = async (requestBody) => {
+  try {
+    const response = await client.post("/api/v1/social/link", requestBody);
+    return response.data;
+  } catch (error) {
+    console.error("소셜 로그인 연동 에러:", error);
+    throw error;
+  }
+};

--- a/src/components/ProfileEditContent.jsx
+++ b/src/components/ProfileEditContent.jsx
@@ -62,10 +62,10 @@ export default function ProfileEditContent() {
         setFormData({
           ...profileData,
           newCategories: newCategories,
-          originalNickname: profileData.nickname, // 원본 닉네임 저장
-          marketingAgreement: profileData.marketingAgreement || false // 마케팅 동의 여부 추가
+          originalNickname: profileData.nickname,
+          marketingAgreement: profileData.marketingAgreement || false
         });
-        setMarketingAgreement(profileData.marketingAgreement || false); // 마케팅 동의 상태 초기화
+        setMarketingAgreement(profileData.marketingAgreement || false);
 
       } else {
         console.error('프로필 데이터 조회 실패:', response.data?.message);
@@ -131,7 +131,7 @@ export default function ProfileEditContent() {
       setSelectedFile(null);
       setNicknameVerified(false);
       setVerificationMessage('');
-      fetchProfileData(); // 수정 성공 후 데이터를 다시 불러옵니다.
+      fetchProfileData();
     },
     onError: (error) => {
       console.error("프로필 수정 실패:", error);
@@ -229,18 +229,25 @@ export default function ProfileEditContent() {
     const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI;
     const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=profile_nickname,account_email,profile_image`;
     
+    // 카카오 연동
     const handleKakaoLogin = () => {
+      if (!isEditing) return;
+      
       localStorage.setItem('socialProvider', 'KAKAO');
+      localStorage.setItem('isLinking', 'true'); // 연동 모드
       window.location.href = KAKAO_AUTH_URL;
     }
   
-    // 구글 로그인
+    // 구글 연동
     const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
     const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
     const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=email profile`;
     
     const handleGoogleLogin = () => {
+      if (!isEditing) return;
+      
       localStorage.setItem('socialProvider', 'GOOGLE');
+      localStorage.setItem('isLinking', 'true'); // 연동 모드
       window.location.href = GOOGLE_AUTH_URL;
     }
 
@@ -361,6 +368,7 @@ export default function ProfileEditContent() {
                     ? 'bg-[#FEE500] hover:shadow-md cursor-pointer' 
                     : 'bg-yellow-300 cursor-not-allowed opacity-60'
                 }`}
+                onClick={handleKakaoLogin}
               >
                 <img src={kakaoLogo} alt="카카오 로그인" className="w-[1.4rem] object-contain" />
                 <p>카카오 계정으로 연동</p>
@@ -372,6 +380,7 @@ export default function ProfileEditContent() {
                     ? 'bg-white border-2 border-gray-200 hover:shadow-md cursor-pointer' 
                     : 'bg-gray-100 border-2 border-gray-300 cursor-not-allowed opacity-60'
                 }`}
+                onClick={handleGoogleLogin}
               >
                 <img src={googleLogo} alt="구글 로그인" className="w-[1.4rem] object-contain" />
                 구글 계정으로 연동

--- a/src/components/ProfileEditContent.jsx
+++ b/src/components/ProfileEditContent.jsx
@@ -224,6 +224,27 @@ export default function ProfileEditContent() {
     }
   };
 
+    // 카카오 로그인
+    const REST_API_KEY = import.meta.env.VITE_REST_API_KEY;
+    const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI;
+    const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=profile_nickname,account_email,profile_image`;
+    
+    const handleKakaoLogin = () => {
+      localStorage.setItem('socialProvider', 'KAKAO');
+      window.location.href = KAKAO_AUTH_URL;
+    }
+  
+    // 구글 로그인
+    const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+    const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
+    const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=email profile`;
+    
+    const handleGoogleLogin = () => {
+      localStorage.setItem('socialProvider', 'GOOGLE');
+      window.location.href = GOOGLE_AUTH_URL;
+    }
+
+    
   if (loading) {
     return <Loading text="프로필 정보를 불러오는 중..." />;
   }
@@ -334,14 +355,23 @@ export default function ProfileEditContent() {
         <h2 className="text-2xl font-bold mb-4">SNS 계정 연동</h2>
         <div className="flex items-center justify-center gap-4">
             <button 
-                className="w-60 bg-[#FEE500] rounded-xl p-4 shadow-sm hover:shadow-md duration-200 flex items-center justify-center gap-4"
+                disabled={!isEditing}
+                className={`w-60 rounded-xl p-4 shadow-sm duration-200 flex items-center justify-center gap-4 ${
+                  isEditing 
+                    ? 'bg-[#FEE500] hover:shadow-md cursor-pointer' 
+                    : 'bg-yellow-300 cursor-not-allowed opacity-60'
+                }`}
               >
-
                 <img src={kakaoLogo} alt="카카오 로그인" className="w-[1.4rem] object-contain" />
                 <p>카카오 계정으로 연동</p>
               </button>
               <button 
-                className="w-60 bg-white border-2 border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md duration-200 flex items-center justify-center gap-7"
+                disabled={!isEditing}
+                className={`w-60 rounded-xl p-4 shadow-sm duration-200 flex items-center justify-center gap-7 ${
+                  isEditing 
+                    ? 'bg-white border-2 border-gray-200 hover:shadow-md cursor-pointer' 
+                    : 'bg-gray-100 border-2 border-gray-300 cursor-not-allowed opacity-60'
+                }`}
               >
                 <img src={googleLogo} alt="구글 로그인" className="w-[1.4rem] object-contain" />
                 구글 계정으로 연동

--- a/src/components/ProfileEditContent.jsx
+++ b/src/components/ProfileEditContent.jsx
@@ -9,6 +9,8 @@ import { useNavigate } from 'react-router-dom';
 import noneCheckBox from "../assets/images/noneCheckBox.png";
 import fillCheckBox from "../assets/images/fillCheckBox.png";
 import Loading from './loading';
+import kakaoLogo from "../assets/images/kakaoLogo.png"
+import googleLogo from "../assets/images/googleLogo.png"
 
 export default function ProfileEditContent() {
   const [isEditing, setIsEditing] = useState(false);
@@ -242,7 +244,14 @@ export default function ProfileEditContent() {
          <div className="absolute top-[40px] left-[225px]">
             <h1 className="text-4xl font-bold ">{formData.nickname}</h1>
         </div>
-        {isEditing ? <></> : <button onClick={() => setIsEditing(true)} className="ml-auto w-40 py-3 bg-yellow-main text-black rounded-lg font-bold transition-colors">수정하기</button>}
+        
+            <div className="flex items-center justify-between gap-4 w-full">
+            {isEditing ? <></> : <button onClick={() => setIsEditing(true)} className="w-40 py-4 bg-yellow-main text-black rounded-xl font-bold transition-colors">수정하기</button>}
+           
+             
+            </div>
+
+        
         <div className="bg-gray-50 p-6 rounded-lg">
           <h2 className="text-2xl font-bold mb-4">개인 정보</h2>
           <div className="grid grid-cols-1 gap-6">
@@ -322,6 +331,24 @@ export default function ProfileEditContent() {
           </div>
         </div>
         <div className="bg-gray-50 p-6 rounded-lg">
+        <h2 className="text-2xl font-bold mb-4">SNS 계정 연동</h2>
+        <div className="flex items-center justify-center gap-4">
+            <button 
+                className="w-60 bg-[#FEE500] rounded-xl p-4 shadow-sm hover:shadow-md duration-200 flex items-center justify-center gap-4"
+              >
+
+                <img src={kakaoLogo} alt="카카오 로그인" className="w-[1.4rem] object-contain" />
+                <p>카카오 계정으로 연동</p>
+              </button>
+              <button 
+                className="w-60 bg-white border-2 border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md duration-200 flex items-center justify-center gap-7"
+              >
+                <img src={googleLogo} alt="구글 로그인" className="w-[1.4rem] object-contain" />
+                구글 계정으로 연동
+              </button>
+            </div>
+            </div>
+        <div className="bg-gray-50 p-6 rounded-lg">
           <h2 className="text-2xl font-bold mb-4">마케팅 수신 동의</h2>
           <button
                 type="button"
@@ -353,6 +380,7 @@ export default function ProfileEditContent() {
            <></>
           )}
       </div>
+      
       <div className='flex justify-between items-center'>
      
       
@@ -364,6 +392,7 @@ export default function ProfileEditContent() {
             회원탈퇴
           </button>
           </div>
+          
     </div>
     </div>
   );

--- a/src/components/buttonInput.jsx
+++ b/src/components/buttonInput.jsx
@@ -19,9 +19,7 @@ export default function ButtonInput({
     disabled = false,
     btnDisabled = false
 }) {
-            useEffect(() => {
-            console.log("버튼 인풋에서", isConfirmed);
-          }, [isConfirmed]);
+        
     return (
 
         

--- a/src/components/join/step1.jsx
+++ b/src/components/join/step1.jsx
@@ -533,7 +533,7 @@ export default function JoinForm({ socialLoginInfo }) {
                       <td>회원 탈퇴 시까지</td>
                     </tr> */}
                     <tr className="border-b border-gray-100">
-                      <td>IP 주소, 서비스 시용 기록</td>
+                      <td>IP 주소, 서비스 사용 기록</td>
                       <td>서비스 개선, 보안 및 로그 기록</td>
                       <td>3년</td>
                     </tr>

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -17,14 +17,6 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [showError, setShowError] = useState(false);
 
-  // showError 상태 변화 디버깅
-  useEffect(() => {
-    console.log("showError 상태 변경:", showError);
-  }, [showError]);
-
-  const handleLoginClick = () => {
-    navigate("/");
-  };
 
   const loginMutation = useMutation({
     mutationFn: ({ email, password }) => postLogin(email, password),

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -41,14 +41,12 @@ export default function Login() {
       localStorage.setItem("accessToken", result.accessToken);
   
       navigate("/");
-      console.log(response)
+
     },
   
     onError: (error) => {
       console.error("로그인 실패:", error);
-      console.log("에러 상태 코드:", error.response?.status);
       setShowError(true);
-      console.log("showError 설정됨:", true);
     },
   });
 

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -17,6 +17,11 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [showError, setShowError] = useState(false);
 
+  // showError 상태 변화 디버깅
+  useEffect(() => {
+    console.log("showError 상태 변경:", showError);
+  }, [showError]);
+
   const handleLoginClick = () => {
     navigate("/");
   };
@@ -35,13 +40,15 @@ export default function Login() {
       UserStore.getState().setAccessToken(result.accessToken);
       localStorage.setItem("accessToken", result.accessToken);
   
-      // navigate("/");
+      navigate("/");
       console.log(response)
     },
   
     onError: (error) => {
       console.error("로그인 실패:", error);
+      console.log("에러 상태 코드:", error.response?.status);
       setShowError(true);
+      console.log("showError 설정됨:", true);
     },
   });
 
@@ -105,27 +112,27 @@ export default function Login() {
         
         onSubmit={(e) => {
           e.preventDefault();
-           console.log('폼 제출됨');
+          //  console.log('폼 제출됨');
           loginMutation.mutate({ email, password })}}
         className="w-full max-w-sm bg-white p-6 lg:p-8 border rounded-xl shadow"
       >
           <Input
             title="이메일"
             // isValidateTrigger={isValidateTrigger}
-            // isConfirmed={isConfirmed}
+            isConfirmed={showError ? false : undefined}
             placeholder="Souf@souf.com"
             onChange={(e) => {
               setEmail(e.target.value);
               setShowError(false);
             }}
             essentialText="이메일을 입력해주세요"
-            disapproveText="이메일을 입력해주세요"
+            disapproveText=""
             // onValidChange={onValidChange}
           />
           <Input
             title="비밀번호"
             // isValidateTrigger={isValidateTrigger}
-            // isConfirmed={isConfirmed}
+            isConfirmed={showError ? false : undefined}
             type="password"
             placeholder=""
             onChange={(e) => {
@@ -133,12 +140,9 @@ export default function Login() {
               setShowError(false);
             }}
             essentialText="비밀번호를 입력해주세요"
-            disapproveText="비밀번호를 입력해주세요"
+            disapproveText={showError ? "아이디 또는 비밀번호가 일치하지 않습니다." : "비밀번호를 입력해주세요"}
             // onValidChange={onValidChange}
           />
-          {showError && (
-            <div className="mt-10 text-red-essential text-center">아이디 또는 비밀번호가 일치하지 않습니다.</div>
-          )}
          
           <div className="flex justify-between text-[#767676] text-xl font-reagular">
             <button type="button" onClick={() => navigate("/join")}>회원가입</button>

--- a/src/pages/redirect.jsx
+++ b/src/pages/redirect.jsx
@@ -86,6 +86,13 @@ export default function Redirect() {
         })
         .catch((error) => {
           console.error("소셜 로그인 에러:", error);
+          
+          // 409 에러 (이미 가입된 이메일) 처리
+          if (error.response?.status === 409) {
+            const errorMessage = error.response?.data?.message || "이미 가입된 이메일입니다. 마이페이지에서 소셜 계정을 연결해주세요.";
+            alert(errorMessage);
+          }
+          
           navigate("/login");
         });
     } else {


### PR DESCRIPTION

## 🔗 연관된 이슈

> #233 

## 🛠️ 작업 내용

> 로그인 관련 에러 문구 위치를 조정하고, 소셜로그인 - 이미 가입된 계정일 경우 로그인 페이지 처리 및 마이페이지에서 연동 API를 따로 연결했습니다.

1. 일반 계정으로 가입된 사용자가 로그인 페이지에서 SNS 계정으로 로그인 버튼을 클릭 시, "이미 가입된 계정입니다. 마이페이지에서 연동해주세요." 문구가 뜨고, SNS 계정으로 로그인할 수 없습니다.

2. 마이페이지에 SNS 연동하기 버튼을 추가했습니다. 일반 계정으로 로그인 후, 마이페이지 접속 시 '수정하기' 버튼을 누르고(`isEditing = true`) SNS 계정으로 연동이 가능합니다.

3. 마이페이지에서 SNS 연동하기 버튼을 클릭할 시, 기존 SNS 로그인 로직에서 `localStorage.setItem('isLinking', 'true');`를 추가했습니다.

4. `redirect.jsx`에서 로컬 스토리지의 'isLinking', 'true'를 확인하면, 기존에 일반 계정으로 가입된 계정의 SNS 연동으로 구분하여 API를 호출합니다.

## 📸 스크린샷
1. 수정상태가 아닐 때 마이페이지
<img width="490" height="742" alt="스크린샷 2025-09-02 오후 7 22 14" src="https://github.com/user-attachments/assets/bdd72f88-1355-4381-85c0-9c65d3090010" />

2. 수정상태일 때 마이페이지 - SNS 계정 연동 버튼도 같이 활성화
<img width="493" height="728" alt="image" src="https://github.com/user-attachments/assets/721ef213-0480-4564-8981-d7f045f01a35" />



