### PR TITLE
!HOTFIX : 공고문 금액&날짜 input 수정

### DIFF
--- a/src/components/recruitBlock.jsx
+++ b/src/components/recruitBlock.jsx
@@ -129,7 +129,7 @@ export default function RecruitBlock({
           content,
           cityName,
           cityDetailName,
-          price,
+          price: payment,
           deadline: deadLine,
           location: cityName,
           preferMajor: false, 

--- a/src/components/recruitBlock.jsx
+++ b/src/components/recruitBlock.jsx
@@ -23,8 +23,6 @@ export default function RecruitBlock({
   deadLine,
   recruitable,
   payment,
-  minPayment,
-  maxPayment,
   cityName,
   cityDetailName,
   secondCategory,
@@ -119,9 +117,6 @@ export default function RecruitBlock({
   };
 
   const handleClick = async () => {
-    const minPrice = parsePayment(minPayment);
-    const maxPrice = parsePayment(maxPayment);
-    
     try {
       const response = await getRecruitDetail(id);
       console.log('Recruit detail response:', response);
@@ -134,8 +129,7 @@ export default function RecruitBlock({
           content,
           cityName,
           cityDetailName,
-          minPrice,
-          maxPrice,
+          price,
           deadline: deadLine,
           location: cityName,
           preferMajor: false, 

--- a/src/pages/recruit.jsx
+++ b/src/pages/recruit.jsx
@@ -431,13 +431,6 @@ useEffect(() => {
             {filteredRecruits.length > 0 ? (
               <>
                 {filteredRecruits.map((recruit) => {
-                  const paymentString =
-                    recruit.minPayment && recruit.maxPayment
-                      ? recruit.minPayment === recruit.maxPayment
-                        ? recruit.minPayment
-                        : `${recruit.minPayment} ~ ${recruit.maxPayment}`
-                      : recruit.minPayment || recruit.maxPayment || "금액 협의";
-
                   return (
                     <RecruitBlock
                       key={recruit.recruitId}
@@ -446,9 +439,7 @@ useEffect(() => {
                       content={recruit.content}
                       deadLine={recruit.deadLine}
                       recruitable = {recruit.recruitable}
-                      payment={paymentString}
-                      minPayment={recruit.minPayment}
-                      maxPayment={recruit.maxPayment}
+                      payment={recruit.price || "금액 협의"}
                       cityName={recruit.cityName}
                       cityDetailName={recruit.cityDetailName}
                       secondCategory={recruit.secondCategory}

--- a/src/pages/recruitDetails.jsx
+++ b/src/pages/recruitDetails.jsx
@@ -21,6 +21,11 @@ const parsePayment = (paymentString) => {
   return isNaN(num) ? null : num;
 };
 
+const formatPayment = (paymentString) => {
+  if (!paymentString || typeof paymentString !== 'string') return '금액 협의';
+  return paymentString;
+};
+
 export default function RecruitDetail() {
   const navigate = useNavigate();
   const { id } = useParams();
@@ -184,8 +189,7 @@ export default function RecruitDetail() {
   const categoryList = recruitDetail?.categoryDtoList || [];
   const mobileCategoryNames = getCategoryNames(categoryList);
   const categoryNames = getAllCategoryNames(categoryList);
-  const minPrice = parsePayment(recruitDetail?.minPayment);
-  const maxPrice = parsePayment(recruitDetail?.maxPayment);
+  const price = formatPayment(recruitDetail?.price);
   const isAuthor = memberId === recruitDetail?.memberId;
 
   // 현재 로그인한 사용자가 공고 작성자인지 확인 (memberId로 비교)
@@ -207,8 +211,7 @@ export default function RecruitDetail() {
     title: displayData?.title,
     nickname: displayData?.nickname,
     categoryNames,
-    minPrice,
-    maxPrice,
+    price,
     deadline: displayData?.deadline,
     location: displayData?.location,
     recruitDetail,
@@ -317,11 +320,7 @@ export default function RecruitDetail() {
               <div>
                 <span className="text-black mb-1">급여</span>
                 <span className="text-gray-500 mx-2">|</span>
-                <span className="font-medium">
-                  {minPrice && maxPrice
-                    ? `${minPrice.toLocaleString()}원 ~ ${maxPrice.toLocaleString()}원`
-                    : '금액 협의'}
-                </span>
+                <span className="font-medium">{price}</span>
               </div>
               <div>
                 <span className="text-black mb-1">기한</span>

--- a/src/pages/recruitUpload.jsx
+++ b/src/pages/recruitUpload.jsx
@@ -23,9 +23,9 @@ export default function RecruitUpload() {
   const [isLoading, setIsLoading] = useState(false);
   
   // 급여 파싱 함수
-  const parsePayment = (paymentString) => {
-    if (!paymentString || typeof paymentString !== 'string') return '';
-    let numStr = paymentString.replace(/[^0-9.]/g, '');
+  const parsePrice = (priceString) => {
+    if (!priceString || typeof priceString !== 'string') return '';
+    let numStr = priceString.replace(/[^0-9.]/g, '');
     return numStr;
   };
 
@@ -50,20 +50,23 @@ export default function RecruitUpload() {
   
   const [formData, setFormData] = useState(() => {
     if (isEditMode && editData) {
-      const dateTime = parseDateTime(editData.deadline);
+      const startDateTime = parseDateTime(editData.startDate);
+      const deadlineDateTime = parseDateTime(editData.deadline);
       return {
         title: editData.title || '',
         content: editData.content || '',
         region: editData.cityDetailName || '',
         city: editData.cityName || '',
-        deadline: dateTime.date,
-        deadlineTime: '00:00',
-        deadlineHour: dateTime.hour,
-        deadlineMinute: dateTime.minute,
-        deadlinePeriod: dateTime.period,
+        startDate: startDateTime.date,
+        startDateHour: startDateTime.hour,
+        startDateMinute: startDateTime.minute,
+        startDatePeriod: startDateTime.period,
+        deadline: deadlineDateTime.date,
+        deadlineHour: deadlineDateTime.hour,
+        deadlineMinute: deadlineDateTime.minute,
+        deadlinePeriod: deadlineDateTime.period,
         companyName: editData.nickname || nickname || '',
-        minPayment: parsePayment(editData.minPayment),
-        maxPayment: parsePayment(editData.maxPayment),
+        price: parsePrice(editData.price),
         isregionIrrelevant: !editData.cityName || editData.cityName === '지역 무관',
         preferentialTreatment: editData.preferentialTreatment || '',
         hasPreference: !!editData.preferentialTreatment,
@@ -93,18 +96,20 @@ export default function RecruitUpload() {
       };
     } else {
       return {
-    title: '',
+        title: '',
         content: '',
         region: '',
         city: '',
-    deadline: '',
-        deadlineTime: '00:00',
+        startDate: '',
+        startDateHour: '01',
+        startDateMinute: '00',
+        startDatePeriod: 'AM',
+        deadline: '',
         deadlineHour: '01',
         deadlineMinute: '00',
         deadlinePeriod: 'AM',
         companyName: nickname || '',
-        minPayment: '',
-        maxPayment: '',
+        price: '',
         isregionIrrelevant: false,
         preferentialTreatment: '',
         hasPreference: false,
@@ -265,6 +270,7 @@ export default function RecruitUpload() {
         cityDetailId = cityDetail ? cityDetail.city_detail_id : null;
       }
   
+      const startDateTime = `${formData.startDate}T${convertTo24HourFormat(formData.startDateHour, formData.startDateMinute, formData.startDatePeriod)}`;
       const deadlineDateTime = `${formData.deadline}T${convertTo24HourFormat(formData.deadlineHour, formData.deadlineMinute, formData.deadlinePeriod)}`;
   
       const formDataToSend = {
@@ -272,9 +278,9 @@ export default function RecruitUpload() {
         content: formData.content,
         cityId: cityId,
         cityDetailId: cityDetailId,
+        startDate: startDateTime,
         deadline: deadlineDateTime,
-        minPayment: `${formData.minPayment}만원`,
-        maxPayment: `${formData.maxPayment}만원`,
+        price: `${formData.price}만원`,
         preferentialTreatment: formData.hasPreference ? formData.preferentialTreatment : '',
         categoryDtos: cleanedCategories,
         originalFileNames: formData.files.map((file) => file.name),
@@ -457,23 +463,8 @@ dtoList.forEach((dto, i) => {
             <div className="flex-1">
               <input
                 type="number"
-                name="minPayment"
-                value={formData.minPayment}
-                onChange={handleChange}
-                className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent ${
-                  isEditMode ? 'bg-gray-100 cursor-not-allowed' : ''
-                }`}
-                required
-                disabled={isEditMode}
-                readOnly={isEditMode}
-              />
-            </div>
-            <span className="text-gray-500">~</span>
-            <div className="flex-1">
-              <input
-                type="number"
-                name="maxPayment"
-                value={formData.maxPayment}
+                name="price"
+                value={formData.price}
                 onChange={handleChange}
                 className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent ${
                   isEditMode ? 'bg-gray-100 cursor-not-allowed' : ''
@@ -562,18 +553,73 @@ dtoList.forEach((dto, i) => {
         </div>
 
         <div className="grid grid-cols-2 gap-6">
-        <div>
-          <label className="block text-xl font-semibold text-gray-700 mb-2">
-              마감 기한
-          </label>
-          <input
-            type="date"
-            name="deadline"
-            value={formData.deadline}
-            onChange={handleChange}
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent"
-            required
-          />
+          <div>
+            <label className="block text-xl font-semibold text-gray-700 mb-2">
+              시작일
+            </label>
+            <input
+              type="date"
+              name="startDate"
+              value={formData.startDate}
+              onChange={handleChange}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent"
+              required
+            />
+          </div>
+          
+          <div>
+            <label className="block text-xl font-semibold text-gray-700 mb-2">
+              시작 시간
+            </label>
+            <div className="flex items-center gap-2">
+              <select
+                name="startDatePeriod"
+                value={formData.startDatePeriod}
+                onChange={handleChange}
+                className="w-1/3 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent"
+              >
+                <option value="AM">오전</option>
+                <option value="PM">오후</option>
+              </select>
+              <select
+                name="startDateHour"
+                value={formData.startDateHour}
+                onChange={handleChange}
+                className="w-1/3 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent"
+              >
+                {Array.from({ length: 12 }, (_, i) => (
+                  <option key={i + 1} value={(i + 1).toString().padStart(2, '0')}>
+                    {i + 1}
+                  </option>
+                ))}
+              </select>
+              <span className="text-gray-500">:</span>
+              <select
+                name="startDateMinute"
+                value={formData.startDateMinute}
+                onChange={handleChange}
+                className="w-1/3 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent"
+              >
+                <option value="00">00</option>
+                <option value="30">30</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-6">
+          <div>
+            <label className="block text-xl font-semibold text-gray-700 mb-2">
+              마감일
+            </label>
+            <input
+              type="date"
+              name="deadline"
+              value={formData.deadline}
+              onChange={handleChange}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-point focus:border-transparent"
+              required
+            />
           </div>
           
           <div>
@@ -581,7 +627,7 @@ dtoList.forEach((dto, i) => {
               마감 시간
             </label>
             <div className="flex items-center gap-2">
-            <select
+              <select
                 name="deadlinePeriod"
                 value={formData.deadlinePeriod}
                 onChange={handleChange}
@@ -612,7 +658,6 @@ dtoList.forEach((dto, i) => {
                 <option value="00">00</option>
                 <option value="30">30</option>
               </select>
-              
             </div>
           </div>
         </div>


### PR DESCRIPTION


## 🛠️ 작업 내용

> 공고문 금액&날짜 input 수정
1. 금액 : 기존은 `minpayment` ~ `maxPayment` 두 개의 입력값을 받았는데 API 변경에 따라 `price` 변수 하나로 통일했습니다. 
2. 날짜 : 기존은 `deadline` 하나의 입력값을 받았는데 API 변경에 따라 `startDate`, `deadline` 두 개의 입력값을 받도록 수정했습니다. 
또한 해당 수정사항을 공고문 업로드 페이지, 공고문 리스트 조회 페이지, 공고문 상세 조회 페이지에서 확인할 수 있습니다. 

## 📸 스크린샷
공고문 업로드
<img width="418" height="470" alt="image" src="https://github.com/user-attachments/assets/d95b2d51-7ad5-4a60-854b-a00828ce5152" />

공고문 조회
<img width="691" height="310" alt="image" src="https://github.com/user-attachments/assets/fc37d149-3db5-4417-84cf-a41d3e0734db" />


## 💬 리뷰 요구사항

> 공고문 리스트 조회, 상세 조회 시 아직 시작일이 데이터 응답으로 넘어오지 않아 해당 부분 백엔드 수정 시 바로 반영 예정입니다. 



