### PR TITLE
REFACTOR : 카테고리 이미지 경로 변경

### DIFF
--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -21,6 +21,28 @@ import { UserStore } from "../store/userStore";
 import useCountUp from "../hooks/useCountUp";
 import SEO from "../components/seo";
 import Loading from "../components/loading";
+import cateIcon11 from "../assets/images/categoryIcons/cateIcon11.png";
+import cateIcon12 from "../assets/images/categoryIcons/cateIcon12.png";
+import cateIcon13 from "../assets/images/categoryIcons/cateIcon13.png";
+import cateIcon24 from "../assets/images/categoryIcons/cateIcon24.png";
+import cateIcon25 from "../assets/images/categoryIcons/cateIcon25.png";
+import cateIcon26 from "../assets/images/categoryIcons/cateIcon26.png";
+import cateIcon27 from "../assets/images/categoryIcons/cateIcon27.png";
+import cateIcon38 from "../assets/images/categoryIcons/cateIcon38.png";
+import cateIcon49 from "../assets/images/categoryIcons/cateIcon49.png";
+import cateIcon410 from "../assets/images/categoryIcons/cateIcon410.png";
+import cateIcon411 from "../assets/images/categoryIcons/cateIcon411.png";
+import cateIcon512 from "../assets/images/categoryIcons/cateIcon512.png";
+import cateIcon513 from "../assets/images/categoryIcons/cateIcon513.png";
+import cateIcon514 from "../assets/images/categoryIcons/cateIcon514.png";
+import cateIcon515 from "../assets/images/categoryIcons/cateIcon515.png";
+import cateIcon516 from "../assets/images/categoryIcons/cateIcon516.png";
+import cateIcon517 from "../assets/images/categoryIcons/cateIcon517.png";
+import cateIcon518 from "../assets/images/categoryIcons/cateIcon518.png";
+import cateIcon619 from "../assets/images/categoryIcons/cateIcon619.png";
+import cateIcon620 from "../assets/images/categoryIcons/cateIcon620.png";
+import cateIcon621 from "../assets/images/categoryIcons/cateIcon621.png";
+import cateIcon622 from "../assets/images/categoryIcons/cateIcon622.png";
 
 
 export default function Home() {
@@ -79,28 +101,28 @@ export default function Home() {
 
   const getCategoryIcon = (categoryId) => {
     const iconMap = {
-      1: "/src/assets/images/categoryIcons/cateIcon11.png", // 일러스트·캐릭터 디자인
-      2: "/src/assets/images/categoryIcons/cateIcon12.png", // 글자 디자인
-      3: "/src/assets/images/categoryIcons/cateIcon13.png", // 순수 미술
-      4: "/src/assets/images/categoryIcons/cateIcon24.png", // 시제품 디자인
-      5: "/src/assets/images/categoryIcons/cateIcon25.png", // 산업·제품 디자인
-      6: "/src/assets/images/categoryIcons/cateIcon26.png", // 패션·텍스타일 디자인
-      7: "/src/assets/images/categoryIcons/cateIcon27.png", // 조형 예술
-      8: "/src/assets/images/categoryIcons/cateIcon38.png", // 음향
-      9: "/src/assets/images/categoryIcons/cateIcon49.png", // 사진
-      10: "/src/assets/images/categoryIcons/cateIcon410.png", // 영상
-      11: "/src/assets/images/categoryIcons/cateIcon411.png", // 영화
-      12: "/src/assets/images/categoryIcons/cateIcon512.png", // 브랜드 디자인
-      13: "/src/assets/images/categoryIcons/cateIcon513.png", // 산업 디자인
-      14: "/src/assets/images/categoryIcons/cateIcon514.png", // 웹·모바일 디자인
-      15: "/src/assets/images/categoryIcons/cateIcon515.png", // 마케팅 디자인
-      16: "/src/assets/images/categoryIcons/cateIcon516.png", // 컴퓨터 그래픽·모션 그래픽
-      17: "/src/assets/images/categoryIcons/cateIcon517.png", // 게임 디자인
-      18: "/src/assets/images/categoryIcons/cateIcon518.png", // 애니메이션
-      19: "/src/assets/images/categoryIcons/cateIcon619.png", // 웹사이트
-      20: "/src/assets/images/categoryIcons/cateIcon620.png", // 안드로이드
-      21: "/src/assets/images/categoryIcons/cateIcon621.png", // IOS
-      22: "/src/assets/images/categoryIcons/cateIcon622.png", // 게임 프로그래밍
+      1: cateIcon11,
+      2: cateIcon12,
+      3: cateIcon13,
+      4: cateIcon24,
+      5: cateIcon25,
+      6: cateIcon26,
+      7: cateIcon27,
+      8: cateIcon38,
+      9: cateIcon49,
+      10: cateIcon410,
+      11: cateIcon411,
+      12: cateIcon512,
+      13: cateIcon513,
+      14: cateIcon514,
+      15: cateIcon515,
+      16: cateIcon516,
+      17: cateIcon517,
+      18: cateIcon518,
+      19: cateIcon619,
+      20: cateIcon620,
+      21: cateIcon621,
+      22: cateIcon622,
     };
     return iconMap[categoryId] || "/src/assets/images/categoryIcons/cateIcon11.png";
   };


### PR DESCRIPTION

## 🛠️ 작업 내용

> 카테고리 이미지가 뜨지 않는 에러 처리
`<img src="/src/assets/images/categoryIcons/cateIcon11.png" ... >`
-> 개발 소스코드 경로라서 빌드 후에 보이지 않음!

(목업 이미지는 public경로에 복사된 파일이라 이미지가 뜸)
`<img src="/assets/soufMockup-Ro6EuGRN.png" ... >`

이미지는 src 폴더에 그대로 두고, import 해서 사용하는 방식으로 수정
(각 이미지를 import 해서 변수에 할당)

## 📸 스크린샷
수정 전

<img width="592" height="182" alt="image" src="https://github.com/user-attachments/assets/062f4966-8e4e-4c98-85ac-dfdf813e2650" />

수정 후
<img width="557" height="159" alt="image" src="https://github.com/user-attachments/assets/d72b99d1-d3e0-451d-a588-bdb4af681b08" />


