### PR TITLE
FEAT : 외주 지원하기 & 견적받기 기능 구현

### DIFF
--- a/src/api/application.js
+++ b/src/api/application.js
@@ -2,9 +2,9 @@ import axios from "axios";
 import client from "./client";
 
 /* 지원하기 */
-export async function postApplication(recruitId) {
+export async function postApplication(recruitId, requestBody) {
     const accessToken = localStorage.getItem('accessToken');
-    const response = await client.post(`/api/v1/applications/${recruitId}/apply`, {}, {
+    const response = await client.post(`/api/v1/applications/${recruitId}/apply`, requestBody, {
         headers: {
             Authorization: `Bearer ${accessToken}`,
         }

--- a/src/api/recruit.js
+++ b/src/api/recruit.js
@@ -23,8 +23,8 @@ export async function getRecruit(params = {}) {
             thirdCategory,
             selectedCategories,
             recruitSearchReqDto = {},
-            page = 0,
-            size = 10,
+            page = page,
+            size = size,
             sort,
         } = params;
 
@@ -100,14 +100,8 @@ export async function getRecruit(params = {}) {
 export async function getRecruitDetail(recruitId) {
     try {
         const token = localStorage.getItem('accessToken');
-        console.log("Token exists:", !!token);
-        if (token) {
-            console.log("Token preview:", token.substring(0, 20) + "...");
-        }
-
         const url = `/api/v1/recruit/${recruitId}`;
      
-
         const response = await client.get(url, {
             headers: {
                 'Authorization': `Bearer ${token}`,
@@ -115,7 +109,7 @@ export async function getRecruitDetail(recruitId) {
             }
         });
         
-        console.log("API Response:", response);
+        // console.log("API Response:", response);
         return response;
     } catch (error) {
         console.error('Recruit Detail API 오류 발생:', error);

--- a/src/components/home/feedGrid.jsx
+++ b/src/components/home/feedGrid.jsx
@@ -16,7 +16,7 @@ export default function FeedGrid() {
 
   useEffect(() => {
     setFeedData(data?.result || []);
-    console.log(data?.result);
+    // console.log(data?.result);
   }, [data]);
 
   useEffect(() => {

--- a/src/components/recruitBlock.jsx
+++ b/src/components/recruitBlock.jsx
@@ -8,23 +8,15 @@ import AlertModal from './alertModal';
 import shareIco from '../assets/images/shareIco.svg';
 import soufMockup from '../assets/images/soufMockup.png';
 
-const parsePayment = (paymentString) => {
-  if (!paymentString || typeof paymentString !== 'string') return 0;
-  let numStr = paymentString.replace(/[^0-9.]/g, '');
-  let num = parseFloat(numStr);
-  if (paymentString.includes('만')) {
-    num *= 10000;
-  }
-  return isNaN(num) ? 0 : num;
-};
 
 export default function RecruitBlock({
   id,
   title,
   content,
   deadLine,
+  startDate,
   recruitable,
-  payment,
+  price,
   cityName,
   cityDetailName,
   secondCategory,
@@ -32,7 +24,6 @@ export default function RecruitBlock({
   imageUrl,
 }) {
   const [showLoginModal, setShowLoginModal] = useState(false);
-  const maxLength = 100;
   const navigate = useNavigate();
   
   const getSecondCategoryNames = (secondCategoryIds) => {
@@ -80,49 +71,20 @@ export default function RecruitBlock({
         cat => cat.third_category_id === thirdCatId
       )?.name || '';
 
-      console.log('Found names:', { firstName, secondName, thirdName });
+      // console.log('Found names:', { firstName, secondName, thirdName });
 
       return { first: firstName, second: secondName, third: thirdName };
     });
 
-    console.log('Final result:', result);
+    // console.log('Final result:', result);
     return result;
   };
 
-  const calculateDday = (deadline, recruitable) => {
-    // recruitable이 false이면 마감
-    if (recruitable === false) return "마감";
-    
-    // deadline이 없으면 마감
-    if (!deadline) return "마감";
-    
-    const today = new Date();
-    const deadlineDate = new Date(deadline);
-    const timeDiff = deadlineDate - today;
-    const dayDiff = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
-    
-    // deadline이 지났으면 마감
-    if (dayDiff <= 0) {
-      return "마감";
-    } else {
-      return `D-${dayDiff}`;
-    }
-  };
-
-  const getDdayStyle = (deadline, recruitable) => {
-    const ddayText = calculateDday(deadline, recruitable);
-    
-    if (ddayText === "마감") {
-      return 'font-regular text-base bg-yellow-main text-gray-500 rounded-lg px-5 py-1';
-    } else {
-      return 'font-semibold text-base bg-yellow-point text-white rounded-lg px-5 py-1';
-    }
-  };
 
   const handleClick = async () => {
     try {
       const response = await getRecruitDetail(id);
-      console.log('Recruit detail response:', response);
+      // console.log('Recruit detail response:', response);
       
       const recruitDetail = response.data.result;
       
@@ -132,8 +94,9 @@ export default function RecruitBlock({
           content,
           cityName,
           cityDetailName,
-          price: payment,
+          price: price,
           deadline: deadLine,
+          startDate: startDate,
           location: cityName,
           preferMajor: false, 
           id,
@@ -144,10 +107,6 @@ export default function RecruitBlock({
     } catch (error) {
       console.error('Error fetching recruit detail:', error);
       
-      // 403 에러인 경우 로그인 모달 표시
-      if (error.response?.status === 403) {
-        setShowLoginModal(true);
-      }
     }
   };
 
@@ -156,11 +115,6 @@ export default function RecruitBlock({
       onClick={handleClick}
       className="flex w-full bg-white rounded-2xl shadow-md mb-4 cursor-pointer border border-gray hover:shadow-md transition-shadow duration-200"
     >
-      {/* <div className="flex items-center gap-2 mb-4">
-        <div className={getDdayStyle(deadLine, recruitable)}>{calculateDday(deadLine, recruitable)}</div>
-        <div className='font-regular text-base bg-[#DFDFDF] text-gray-500 rounded-lg px-4 py-1'>{cityName + " " + cityDetailName}</div>
-       
-      </div> */}
       
         {imageUrl ? (
           <img src={imageUrl} alt="공고문 이미지" className="w-40 h-40 rounded-2xl object-cover" />
@@ -211,7 +165,7 @@ export default function RecruitBlock({
       <div className="flex flex-col items-start justify-center gap-2 max-w-48 px-2">
         <div className="flex items-center gap-4">
           <span className="text-xs font-medium text-black ">견적 비용</span>
-          <span className="text-sm font-regular text-black ">{payment}</span>
+          <span className="text-sm font-regular text-black ">{price}</span>
         </div>
         {/* <div className="flex flex-col gap-1">
           <span className="text-xs font-medium text-black ">우대사항</span>
@@ -222,8 +176,13 @@ export default function RecruitBlock({
           </ul>
         </div> */}
          <div className="flex items-center gap-4">
-           <span className="text-xs font-medium text-black ">납기일</span>
-           <span className="text-sm font-regular text-black ">{deadLine ? deadLine.split(' ')[0] : ''}</span>
+         <span className="text-xs font-medium text-black ">납기일</span>
+          <div className="flex flex-col items-end text-right">
+          <span className="text-sm font-regular text-black ">{startDate ? startDate.split(' ')[0] : ''}</span>
+          <span className="text-sm font-regular text-black ">~ {deadLine ? deadLine.split(' ')[0] : ''}</span>
+          </div>
+          
+          
          </div>
        
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -68,7 +68,7 @@ input {
 @font-face {
   font-family: 'Pretendard';
   src: url('./assets/fonts/PretendardVariable.ttf') format('truetype');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
   font-display: swap;
 }

--- a/src/pages/recruit.jsx
+++ b/src/pages/recruit.jsx
@@ -43,7 +43,7 @@ export default function Recruit() {
   const [totalPages, setTotalPages] = useState(1);
   const [showMobileCategoryMenu, setShowMobileCategoryMenu] = useState(false);
   const [sortBy, setSortBy] = useState('RECENT_DESC');
-  const pageSize = 10;
+  const pageSize = 12;
 
 
   const filterOptions = [
@@ -98,10 +98,9 @@ export default function Recruit() {
 
       if (response.data) {
         const recruits = response.data.result?.content || [];
-        console.log("공고문 데이터:", recruits);
+        // console.log("공고문 데이터:", recruits);
        
         setFilteredRecruits(recruits);
-
         const totalElements =
           response.data.result?.page?.totalElements || recruits.length;
         const totalPagesData = response.data.result?.page?.totalPages;
@@ -336,12 +335,6 @@ export default function Recruit() {
           {filteredRecruits.length > 0 ? (
             <>
               {filteredRecruits.map((recruit, index) => {
-                const paymentString =
-                  recruit.minPayment && recruit.maxPayment
-                    ? recruit.minPayment === recruit.maxPayment
-                      ? recruit.minPayment
-                      : `${recruit.minPayment} ~ ${recruit.maxPayment}`
-                    : recruit.minPayment || recruit.maxPayment || "금액 협의";
 
                 return (
                   <div key={recruit.recruitId}>
@@ -350,8 +343,9 @@ export default function Recruit() {
                       title={recruit.title}
                       content={recruit.content}
                       deadLine={recruit.deadLine}
+                      startDate={recruit.startDate}
                       recruitable = {recruit.recruitable}
-                      payment={recruit.price || "금액 협의"}
+                      price={recruit.price || "견적 희망"}
                       cityName={recruit.cityName}
                       cityDetailName={recruit.cityDetailName}
                       secondCategory={recruit.secondCategory}

--- a/src/pages/recruitDetails.jsx
+++ b/src/pages/recruitDetails.jsx
@@ -15,26 +15,9 @@ import PageHeader from "../components/pageHeader";
 import { getAllCategoryNames, getCategoryNames } from '../utils/categoryUtils.js';
 
 
-const parsePayment = (paymentString) => {
-  if (!paymentString || typeof paymentString !== 'string') return null;
-  let numStr = paymentString.replace(/[^0-9.]/g, '');
-  let num = parseFloat(numStr);
-  if (paymentString.includes('만')) {
-    num *= 10000;
-  }
-  return isNaN(num) ? null : num;
-};
-
 const formatPayment = (paymentString) => {
-  if (!paymentString || typeof paymentString !== 'string') return '금액 협의';
+  if (!paymentString || typeof paymentString !== 'string') return '견적 희망';
   return paymentString;
-};
-
-// 닉네임 마스킹 함수
-const maskNickname = (nickname) => {
-  if (!nickname) return '';
-  if (nickname.length <= 2) return nickname;
-  return nickname.charAt(0) + '*'.repeat(nickname.length - 2) + nickname.charAt(nickname.length - 1);
 };
 
 export default function RecruitDetail() {
@@ -50,6 +33,9 @@ export default function RecruitDetail() {
   const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
   const [isCloseSuccessModalOpen, setIsCloseSuccessModalOpen] = useState(false);
   const [isAlreadyClosedModalOpen, setIsAlreadyClosedModalOpen] = useState(false);
+  const [isEstimateModalOpen, setIsEstimateModalOpen] = useState(false);
+  const [priceOffer, setPriceOffer] = useState('');
+  const [priceReason, setPriceReason] = useState('');
   const S3_BUCKET_URL = import.meta.env.VITE_S3_BUCKET_URL;
 
 
@@ -60,7 +46,7 @@ export default function RecruitDetail() {
       console.log('Using API recruit detail:', recruitData.result);
     } else if (recruitData?.recruitDetail) {
       setRecruitDetail(recruitData.recruitDetail);
-      console.log('Using API recruit detail:', recruitData.recruitDetail);
+      // console.log('Using API recruit detail:', recruitData.recruitDetail);
     }
   }, [recruitData]);
 
@@ -162,7 +148,11 @@ export default function RecruitDetail() {
 
   const handleApply = () => {
     console.log('지원 버튼 클릭');
-    setIsApplyModalOpen(true);
+    if (!displayData?.price || displayData.price === '견적 희망') {
+      setIsEstimateModalOpen(true);
+    } else {
+      setIsApplyModalOpen(true);
+    }
   };
 
   const handleViewApplicants = () => {
@@ -172,7 +162,10 @@ export default function RecruitDetail() {
 
   const handleApplyTrue = async () => {
     try {
-      const response = await postApplication(id);
+      const response = await postApplication(id, {
+       priceOffer: priceOffer,
+       priceReason: priceReason,
+      });
       console.log("지원 성공:", response.data);
       setIsApplyModalOpen(false);
       setIsApplySuccessModalOpen(true);
@@ -187,7 +180,40 @@ export default function RecruitDetail() {
       setIsApplyModalOpen(false);
     }
     setIsApplyModalOpen(false);
+
     setIsApplySuccessModalOpen(true);
+  };
+
+  const handleEstimateSubmit = async () => {
+    if (!priceOffer.trim() || !priceReason.trim()) {
+      alert("견적 금액과 사유를 모두 입력해주세요.");
+      return;
+    }
+
+    const numericValue = priceOffer.replace(/[^0-9]/g, '');
+    const priceOfferWithUnit = numericValue + '만원';
+
+    try {
+      const response = await postApplication(id, {
+        priceOffer: priceOfferWithUnit,
+        priceReason: priceReason,
+      });
+      console.log("견적 제출 성공:", response.data);
+      setIsEstimateModalOpen(false);
+      setIsApplySuccessModalOpen(true);
+
+      setPriceOffer('');
+      setPriceReason('');
+    } catch (error) {
+      console.error("견적 제출 실패:", error);
+      if (error.response?.status === 403) {
+        alert("학생 계정만 지원이 가능합니다.");
+        navigate('/login');
+      } else {
+        alert("견적 제출 중 오류가 발생했습니다.");
+      }
+      setIsEstimateModalOpen(false);
+    }
   };
 
   const displayData = recruitDetail;
@@ -195,13 +221,11 @@ export default function RecruitDetail() {
   const mobileCategoryNames = getCategoryNames(categoryList);
   const categoryNames = getAllCategoryNames(categoryList);
   const price = formatPayment(recruitDetail?.price);
-  const maxPrice = parsePayment(recruitDetail?.price);
   const isAuthor = memberId === recruitDetail?.memberId;
 
   // 현재 로그인한 사용자가 공고 작성자인지 확인 (memberId로 비교)
   //const isAuthor = memberId === (recruitDetail?.memberId || displayData?.memberId);
 
-  // 데이터가 없으면 로딩 상태 표시
   if (!displayData) {
     return (
       <div className="pt-16 px-8 w-5/6 mx-auto">
@@ -218,6 +242,7 @@ export default function RecruitDetail() {
     nickname: displayData?.nickname,
     categoryNames,
     price,
+    startDate: displayData?.startDate,
     deadline: displayData?.deadline,
     location: displayData?.location,
     recruitDetail,
@@ -249,8 +274,8 @@ export default function RecruitDetail() {
       />
      
       
-      <div className="flex w-full mx-auto max-w-[60rem] pb-40">
-        <div className="w-5/6 mx-auto pt-4 mr-4">
+      <div className="flex w-full mx-auto max-w-[60rem] pb-40 gap-12">
+        <div className="w-2/3 mx-auto pt-4">
         <button 
           className="flex items-center text-gray-600 mb-4 hover:text-black transition-colors"
           onClick={handleGoBack}
@@ -290,10 +315,7 @@ export default function RecruitDetail() {
                 )}
               </div>
             ) : (
-              <DeclareButton 
-                contentType="공고문" 
-                iconClassName="w-5 h-5 cursor-pointer"
-              />
+              <></>
             )}
           </div>
           <div className="flex items-center gap-2 my-2">
@@ -301,7 +323,7 @@ export default function RecruitDetail() {
         
         <div key={index}>
           {category.third ? (
-            <span className="font-medium text-black">#{category.third}</span>
+            <span className="font-medium text-neutral-500 text-xs">#{category.third}</span>
           ) : category.second ? (
             <span>#{category.second}</span>
           ) : (
@@ -311,19 +333,26 @@ export default function RecruitDetail() {
       ))}
           </div>
          
-          <div className="text-xl font-bold mb-2">{displayData?.nickname}</div>
-          <div className="flex items-center gap-2">
-            <span className="text-zinc-700 text-lg font-bold">프로젝트 소개</span>
-            <div className="text-white font-semibold bg-blue-main px-3 py-1 rounded-md">팝업</div>
-            <div className="text-white font-semibold bg-blue-main px-3 py-1 rounded-md">패션디자인 전공</div>
+          <div className="text-xs font-bold mb-2">{displayData?.nickname}</div>
+          <div className="flex justify-between items-center">
+          {/* <div className="flex items-center gap-2">
+            <span className="text-zinc-700 text-lg font-bold mr-2">프로젝트 소개</span>
+            <div className="text-white font-semibold bg-blue-600 px-3 py-1 rounded-md">팝업</div>
+            <div className="text-white font-semibold bg-blue-600 px-3 py-1 rounded-md">패션디자인 전공</div>
+          </div> */}
+          <DeclareButton 
+                contentType="공고문" 
+                iconClassName="w-5 h-5 cursor-pointer"
+              />
           </div>
+         
 
           <div className="border-t border-gray-200 my-4 sm:my-6"></div>
           <div>
-             <p className="text-xl font-semibold text-black mb-4">
+             <p className="text-sm font-semibold text-black mb-4">
                기업 소개
              </p>
-             <div className="prose prose-lg max-w-none text-gray-800 mb-4">
+             <div className="prose prose-lg max-w-none text-gray-800 mb-4 text-sm">
                <ReactMarkdown 
                  remarkPlugins={[remarkGfm]}
                  rehypePlugins={[rehypeRaw]}
@@ -357,34 +386,43 @@ export default function RecruitDetail() {
           </div>
         </div>
         {/* 우측 외주 조건 */}
-        <div className="sticky top-24 w-1/4 bg-[#FCFCFC] mt-10 p-6 h-fit rounded-lg shadow-md">
+        <div className="sticky top-24 w-1/3 bg-[#FCFCFC] mt-10 p-6 h-fit rounded-lg shadow-md text-sm">
             <div className="space-y-4">
               <div className="flex items-center justify-between">
                 <span className="text-neutral-600 mb-1">급여</span>
                 <span className="font-lg">
-                  {maxPrice
-                    ? `${maxPrice.toLocaleString()}원`
-                    : '금액 협의'}
+                  {price
+                    ? `${price.toLocaleString()}`
+                    : '견적 희망'}
                 </span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-neutral-600 mb-1">납기일</span>
-                <span className="font-lg">{formatDate(displayData?.deadline)}</span>
+                <span className="text-neutral-600 mb-1 whitespace-nowrap">납기일</span>
+                <div className="flex flex-col items-center gap-2 text-right">
+                <span className="font-lg">{formatDate(displayData?.startDate)}</span>
+                <span className="font-lg">~{formatDate(displayData?.deadline)}</span>
+                </div>
               </div>
             </div>
             {isAuthor ? (
             <></>
           ) : (
             <div className="flex justify-between gap-4 mt-6 mb-4">
-              <button className="bg-zinc-300 text-black w-1/2 py-2 rounded-lg text-lg font-bold">문의하기</button>
+              <button className="bg-zinc-800 text-white w-1/2 py-2 rounded-lg text-base font-bold"
+              onClick={() =>alert("문의하기 기능은 준비 중입니다.")}>문의하기</button>
               {recruitDetail?.recruitable ? (
-                <button className="bg-blue-main text-white w-1/2 py-2 rounded-lg text-lg font-bold">{maxPrice ? '지원하기' : '견적 보내기'}</button>
+                <button 
+                  onClick={handleApply}
+                  className="bg-blue-600 text-white w-1/2 py-2 rounded-lg text-base font-bold"
+                >
+                  {(!displayData?.price || displayData.price === '견적 희망') ? '견적 보내기' : '지원하기'}
+                </button>
               ) : (
-                <button className="bg-gray-400 text-black w-1/2 py-2 rounded-lg text-lg font-bold cursor-not-allowed" disabled>지원 마감</button>
+                <button className="bg-gray-400 text-black w-1/2 py-2 rounded-lg text-base font-bold cursor-not-allowed" disabled>지원 마감</button>
               )}
             </div>
           )}
-          <span className="text-zinc-500">이 외주를 총 <span className="text-black font-bold">32명</span>이 조회하였습니다.</span>
+          <span className="text-zinc-500">이 외주를 총 <span className="text-black font-bold">{displayData?.totalViewCount}</span>명이 조회하였습니다.</span>
           </div>
   {isApplyModalOpen && (
         <AlertModal
@@ -450,6 +488,64 @@ export default function RecruitDetail() {
           TrueBtnText="확인"
           onClickTrue={() => setIsAlreadyClosedModalOpen(false)}
         />
+      )}
+      {isEstimateModalOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 w-96 max-w-md mx-4">
+            <h3 className="text-xl font-bold mb-4 text-center">견적 보내기</h3>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  견적 금액
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={priceOffer}
+                    onChange={(e) => {
+                      // 숫자만 입력 허용
+                      const value = e.target.value.replace(/[^0-9]/g, '');
+                      setPriceOffer(value);
+                    }}
+                    placeholder="예: 50"
+                    className="w-40 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <span>만원</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  견적 사유
+                </label>
+                <textarea
+                  value={priceReason}
+                  onChange={(e) => setPriceReason(e.target.value)}
+                  placeholder="예: 리서치/시안 2안 포함"
+                  rows={3}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+            <div className="flex justify-center gap-3 mt-6">
+              <button
+                onClick={() => {
+                  setIsEstimateModalOpen(false);
+                  setPriceOffer('');
+                  setPriceReason('');
+                }}
+                className="px-6 py-2 text-gray-600 border border-gray-300 rounded-lg font-semibold hover:shadow-md"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleEstimateSubmit}
+                className="px-4 py-2 bg-blue-500 text-white rounded-lg font-semibold hover:shadow-md"
+              >
+                견적 보내기
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       </div>


### PR DESCRIPTION

## 🛠️ 작업 내용

> 외주 페이지의 가격 데이터에 따라 지원하기 / 견적 보내기 버튼이 있고, 그에 따른 기능을 구현했습니다.

1. 지원하기
: `price` 데이터가 있을 때, 지원하기 버튼이 생깁니다. 해당 버튼을 누르면 기존 로직과 동일하게 작동합니다.
2. 견적 보내기
: `price` 데이터가 `null`값일 때, 견적 보내기 버튼이 생깁니다. 견적 보내기 버튼을 누르면 희망 금액과 사유를 받고, 두 값을 requestBody로 함께 전송합니다.

## 📸 스크린샷

금액에 따른 지원하기 / 견적 보내기 버튼 구분
<img width="213" height="165" alt="스크린샷 2025-09-29 오후 7 19 41" src="https://github.com/user-attachments/assets/5ad3525b-3ca8-4924-8ddd-cd1ba17e3f89" />
<img width="205" height="164" alt="스크린샷 2025-09-29 오후 7 19 48" src="https://github.com/user-attachments/assets/25415709-1e90-4281-b537-3c94ac5c433c" />


견적 보내기 버튼 클릭 시
<img width="641" height="397" alt="스크린샷 2025-09-29 오후 7 19 58" src="https://github.com/user-attachments/assets/b612f109-a56d-4bab-adf5-be7eae08906b" />

-> 견적 금액은 숫자만 입력할 수 있고, API 호출 후 "만원" 글자를 붙여 string으로 전달합니다. 




