### PR TITLE
DESIGN : 디자인 QA 반영

### DIFF
--- a/src/components/alertModal.jsx
+++ b/src/components/alertModal.jsx
@@ -41,7 +41,7 @@ export default function AlertModal({
             </button>
           )}
           <button
-            className="w-full py-3 px-5 bg-yellow-main rounded-[10px] font-semibold text-base whitespace-nowrap"
+            className="w-full py-3 px-5 bg-blue-main rounded-[10px] font-semibold text-base whitespace-nowrap text-white"
             onClick={onClickTrue}
           >
             {TrueBtnText}

--- a/src/components/categorySelectBox.jsx
+++ b/src/components/categorySelectBox.jsx
@@ -92,15 +92,18 @@ export default function CategorySelectBox({
     setSelectedOption(option);
     setSelectedSubOption(null);
     setSelectedSubSubOption(null);
+    // onChange는 호출하지 않음 - 선택 완료 버튼을 눌렀을 때만 호출
   };
 
   const handleSubOptionSelect = (subOption) => {
     setSelectedSubOption(subOption);
     setSelectedSubSubOption(null);
+    // onChange는 호출하지 않음 - 선택 완료 버튼을 눌렀을 때만 호출
   };
 
   const handleSubSubOptionSelect = (subSubOption) => {
     setSelectedSubSubOption(subSubOption);
+    // onChange는 호출하지 않음 - 선택 완료 버튼을 눌렀을 때만 호출
   };
 
   const getValueToSave = () => {
@@ -130,9 +133,12 @@ export default function CategorySelectBox({
     };
   };
 
+  const hasValidSelection = () => {
+    return selectedOption !== null;
+  };
+
   const handleSave = () => {
     const valueToSave = getValueToSave();
-    console.log('CategorySelectBox - 선택된 카테고리 값:', valueToSave);
     
     // 선택된 카테고리들을 계층적으로 표시
     let displayValue = "";
@@ -147,9 +153,12 @@ export default function CategorySelectBox({
     }
     
     setSelectedValue(displayValue);
-    if (onChange) {
+    
+    // 모달이 열려있을 때만 onChange 호출
+    if (showModal && onChange) {
       onChange(valueToSave);
     }
+    
     setShowModal(false);
   };
 
@@ -220,8 +229,24 @@ export default function CategorySelectBox({
 
       {/* 선택 모달 */}
       {showModal && isEditing && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-          <div className="bg-white rounded-lg shadow-xl p-6 w-[50rem] category-modal">
+        <div 
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setShowModal(false);
+          }}
+        >
+          <div 
+            className="bg-white rounded-lg shadow-xl p-6 w-[50rem] category-modal"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                e.stopPropagation();
+              }
+            }}
+          >
             <style>
               {`
                 @keyframes slideInFromLeft {
@@ -260,6 +285,7 @@ export default function CategorySelectBox({
                  {options.map((option) => (
                    <button
                      key={option.id}
+                     type="button"
                      className={`text-left p-3 my-1 rounded-md transition-all duration-300 ease-in-out transform hover:scale-105 ${getOptionButtonStyle(
                        option
                      )}`}
@@ -281,6 +307,7 @@ export default function CategorySelectBox({
                      {selectedOption.subOptions.map((subOption, index) => (
                        <button
                          key={subOption.id}
+                         type="button"
                          className={`text-left p-3 my-1 rounded-md transition-all duration-300 ease-in-out transform hover:scale-105 ${
                            getSubOptionButtonStyle(subOption)
                          }`}
@@ -312,6 +339,7 @@ export default function CategorySelectBox({
                        {selectedSubOption.subOptions.map((subSubOption, index) => (
                          <button
                            key={subSubOption.id}
+                           type="button"
                            className={`text-left p-3 my-1 rounded-md transition-all duration-300 ease-in-out transform hover:scale-105 ${
                              getSubSubOptionButtonStyle(subSubOption)
                            }`}
@@ -331,17 +359,19 @@ export default function CategorySelectBox({
 
             <div className="flex justify-end mt-4">
               <button
+                type="button"
                 className="bg-gray-200 text-gray-800 px-4 py-2 rounded-md mr-2"
                 onClick={() => setShowModal(false)}
               >
                 취소
               </button>
               <button
+                type="button"
                 className={`bg-blue-main text-white px-4 py-2 rounded-md ${
-                  !getValueToSave() ? "opacity-50 cursor-not-allowed" : ""
+                  !hasValidSelection() ? "opacity-50 cursor-not-allowed" : ""
                 }`}
                 onClick={handleSave}
-                disabled={!getValueToSave()}
+                disabled={!hasValidSelection()}
               >
                 선택 완료
               </button>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -320,7 +320,7 @@ const DesktopHeader = () => (
                   <UserTypeLabel />
                 </button>
                 {showUserMenu && (
-                  <div className="fixed right-40 mt-2 w-36 bg-white rounded-lg shadow-lg py-1 z-[999999] border border-gray-200">
+                  <div className="fixed right-70 mt-2 w-36 bg-white rounded-lg shadow-lg py-1 z-[999999] border border-gray-200">
                     <button
                       className="block w-full px-4 py-2 text-md font-semibold text-gray-700 hover:text-blue-main"
                       onClick={() => handleNavigation("/mypage")}

--- a/src/components/home/EstimateBanner.jsx
+++ b/src/components/home/EstimateBanner.jsx
@@ -74,8 +74,8 @@ export default function FreeEstimate({color}) {
       {showAlertModal && (
         <AlertModal
           type="simple"
-          title="로그인 후 이용해주세요."
-          description="외주 등록은 일반 회원만 이용할 수 있습니다."
+          title="권한이 없습니다."
+          description="외주 등록은 기업 회원만 이용할 수 있습니다."
           TrueBtnText="로그인하러 가기"
           FalseBtnText="취소"
           onClickTrue={() => {

--- a/src/components/recruit/recommendRecruit.jsx
+++ b/src/components/recruit/recommendRecruit.jsx
@@ -42,13 +42,13 @@ export default function RecommendRecruit() {
           <h1 className="text-sm font-semibold mb-4">비슷한 외주를 찾아봤어요</h1>
           <div className="flex flex-col gap-2 bg-blue-50 rounded-md p-4 mb-4">
             <p className="text-blue-600 text-sm font-bold">스프에서 찾아봤어요! (AI 탐색)</p>
-            <div className="flex gap-2">
+            <div className="flex gap-4 items-center justify-center">
               {recruitData.map((recruit) => (
                 <img 
                   key={recruit.recruitId}
                   src={recruit.imageUrl? recruit.imageUrl : soufMockup} 
                   alt={recruit.title} 
-                  className="w-40 h-40 rounded-md cursor-pointer" 
+                  className="w-40 h-40 rounded-md cursor-pointer hover:shadow-lg transition-shadow duration-200" 
                   onClick={() => navigate(`/recruitDetails/${recruit.recruitId}`)}
                 />
               ))}

--- a/src/components/recruit/recruitBlock.jsx
+++ b/src/components/recruit/recruitBlock.jsx
@@ -161,11 +161,11 @@ export default function RecruitBlock({
       </div> */}
         
       </div>
-      <div className="w-[1px] bg-gray-200 self-stretch"></div>
-      <div className="flex flex-col items-start justify-center gap-2 w-44 px-2">
+      <div className="w-[1px] bg-gray-200 self-stretch my-2"></div>
+      <div className="flex flex-col items-start gap-4 w-44 px-2 mt-4">
         <div className="flex items-center gap-4 justify-between w-full">
           <span className="text-xs font-medium text-black ">견적 비용</span>
-          <span className="text-xs font-regular text-black ">{price}</span>
+          <span className="text-md font-regular text-black ">{price}</span>
         </div>
         {/* <div className="flex flex-col gap-1">
           <span className="text-xs font-medium text-black ">우대사항</span>
@@ -175,11 +175,11 @@ export default function RecruitBlock({
             <li>회화과</li>
           </ul>
         </div> */}
-         <div className="flex items-center gap-4 justify-between w-full">
-         <span className="text-xs font-medium text-black whitespace-nowrap">납기일</span>
-          <div className="flex flex-col items-end text-right">
-          <span className="text-xs font-regular text-black ">{startDate ? startDate.split(' ')[0] : ''}</span>
-          <span className="text-xs font-regular text-black ">~ {deadLine ? deadLine.split(' ')[0] : ''}</span>
+         <div className="flex gap-4 justify-between w-full">
+         <span className="text-xs font-medium text-black whitespace-nowrap">마감일</span>
+          <div className="flex flex-col items-start">
+          <span className="text-md font-regular text-black ">{startDate ? startDate.split(' ')[0] : ''}~ </span>
+          <span className="text-md font-regular text-black ">{deadLine ? deadLine.split(' ')[0] : ''}</span>
           </div>
           
           

--- a/src/components/studentProfile/profile.jsx
+++ b/src/components/studentProfile/profile.jsx
@@ -54,7 +54,7 @@ export default function Profile({
 
   return (
     <div
-      className="flex relative items-center justify-start w-full bg-[#DFEFFF] rounded-[20px] p-2 pl-8 gap-2 cursor-pointer hover:shadow-md transition-all"
+      className="flex relative items-center justify-start w-[70%] bg-[#DFEFFF] rounded-[20px] p-2 pl-8 gap-2 cursor-pointer hover:shadow-md transition-all"
     >
       <div className="absolute top-4 right-4 bg-blue-main p-2 rounded-lg">
       <img className=" w-4 z-[5]" src={sendIco} onClick={() => handleChat(memberId)} />

--- a/src/components/studentProfile/profile.jsx
+++ b/src/components/studentProfile/profile.jsx
@@ -54,13 +54,13 @@ export default function Profile({
 
   return (
     <div
-      className="flex relative items-center justify-start w-[70%] bg-blue-bright rounded-[20px] p-2 pl-8 gap-2 cursor-pointer hover:shadow-md transition-all"
+      className="flex relative items-center justify-start w-full bg-blue-bright rounded-[20px] p-2 pl-8 gap-2 cursor-pointer hover:shadow-md transition-all"
     >
       <div className="absolute top-4 right-4 bg-blue-main p-2 rounded-lg">
       <img className=" w-4 z-[5]" src={sendIco} onClick={() => handleChat(memberId)} />
       </div>
       
-      <div className="flex items-center justify-center gap-8"
+      <div className="w-full flex items-center justify-start gap-8"
       onClick={() => clickHandler(memberId)}>
         <div className="flex flex-col items-center justify-center border-r border-gray-200 pr-8">
         <img 
@@ -93,8 +93,7 @@ export default function Profile({
             ))}
           </div>
         ) : (
-          <div className="flex items-center justify-center gap-4">
-            <img src={SoufLogoBlack} alt="SouF 로고" className="w-32 h-32 object-contain rounded-lg" />
+          <div className="flex items-center justify-center mx-auto">
             <span className="text-gray-500 text-sm">작성된 피드가 없습니다.</span>
           </div>
         )}

--- a/src/components/studentProfile/profile.jsx
+++ b/src/components/studentProfile/profile.jsx
@@ -54,7 +54,7 @@ export default function Profile({
 
   return (
     <div
-      className="flex relative items-center justify-start w-full bg-blue-bright rounded-[20px] p-2 pl-8 gap-2 cursor-pointer hover:shadow-md transition-all"
+      className="flex relative items-center justify-start w-full bg-[#DFEFFF] rounded-[20px] p-2 pl-8 gap-2 cursor-pointer hover:shadow-md transition-all"
     >
       <div className="absolute top-4 right-4 bg-blue-main p-2 rounded-lg">
       <img className=" w-4 z-[5]" src={sendIco} onClick={() => handleChat(memberId)} />

--- a/src/components/withdraw/withdrawConfirm.jsx
+++ b/src/components/withdraw/withdrawConfirm.jsx
@@ -60,14 +60,14 @@ export default function WithdrawalConfirm() {
       <div className="flex justify-center gap-4">
         <button
           onClick={() => navigate("/")}
-          className="px-6 py-3 rounded-md bg-gray-200 font-bold hover:bg-gray-300"
+          className="px-6 py-3 rounded-md bg-gray-200 font-bold hover:shadow-md"
         >
           취소
         </button>
         <button
           onClick={handleSubmit}
           disabled={withdrawMutation.isPending}
-          className="px-6 py-3 rounded-md bg-red-500 text-white font-bold hover:bg-red-600 disabled:opacity-50"
+          className="px-6 py-3 rounded-md bg-red-500 text-white font-bold hover:shadow-md disabled:opacity-50"
         >
           {withdrawMutation.isPending ? "처리 중..." : "탈퇴"}
         </button>

--- a/src/components/withdraw/withdrawDescription.jsx
+++ b/src/components/withdraw/withdrawDescription.jsx
@@ -9,7 +9,7 @@ export default function WithdrawDescription({ onWithdraw }) {
   return (
     <>
       <h1 className="text-3xl font-bold mb-2 text-gray-800">지금 떠나시면 ...</h1>
-      <h1 className="text-3xl font-bold mb-6 text-[#FFC105]">데이터가 영영 사라져요 🥹</h1>
+      <h1 className="text-3xl font-bold mb-6 text-blue-main">데이터가 영영 사라져요 🥹</h1>
       <p className="mb-6 text-gray-600">
         탈퇴 시 모든 데이터는 복구할 수 없습니다.<br/>
         또한, 탈퇴 시 해당 이메일은 7일간 재가입이 불가능합니다.<br/>
@@ -18,13 +18,13 @@ export default function WithdrawDescription({ onWithdraw }) {
       <div className="flex justify-center gap-4">
         <button
           onClick={() => navigate(-1)}
-          className="px-6 py-3 rounded-md bg-gray-200 font-bold hover:bg-gray-300"
+          className="px-6 py-3 rounded-md bg-gray-200 font-bold hover:shadow-md"
         >
           취소
         </button>
         <button
           onClick={onWithdraw}
-          className="px-6 py-3 rounded-md bg-[#FFE58F] font-bold hover:bg-[#FFC105]"
+          className="px-6 py-3 rounded-md bg-blue-main font-bold hover:shadow-md text-white"
         >
           탈퇴하기
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,14 @@ body {
   from { opacity: 0; transform: translateY(-10px);}
   to   { opacity: 1; transform: translateY(0);}
 }
+@keyframes bounceLeft {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-5px); }
+}
+@keyframes bounceRight {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(5px); }
+}
 .animate-countup-in {
   animation: countup-in 0.3s forwards;
 }

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -395,27 +395,27 @@ export default function Home() {
        <div className="flex flex-col justify-center gap-2 items-center max-w-[60rem] mx-auto">
        <div className="flex items-center justify-between w-full">
          <span className="text-black text-2xl font-bold">어떤 아이디어/프로젝트가 필요하세요?</span>
-         <div className="flex items-center gap-2">
-           <span className="text-gray-700 text-sm font-light">좌우로 슬라이드해보세요</span>
-           <div className="flex items-center gap-1">
-             
-             {/* 우측 화살표 */}
+       </div>
+       <div className="flex items-center justify-between w-full">
+        {/* 좌측 화살표 */}
+        <div className="flex items-center justify-center w-8 h-8 pointer-events-none">
              <svg 
-               className="w-4 h-4 text-gray-500" 
+               className="w-5 h-5 text-gray-400" 
                fill="none" 
                stroke="currentColor" 
                viewBox="0 0 24 24"
                style={{
-                 animation: 'bounceRight 1.5s ease-in-out infinite'
+                 animation: 'bounceLeft 1.5s ease-in-out infinite'
                }}
              >
-               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
              </svg>
            </div>
-         </div>
-       </div>
        <div className="w-full overflow-x-auto py-4 scrollbar-hide mt-4">
+         
          <div className="flex gap-1 items-center" style={{ width: 'max-content' }}>
+          
+           
            {Array.isArray(categoryItems) && categoryItems.map((category) => (
              <div 
                key={category.second_category_id} 
@@ -432,7 +432,26 @@ export default function Home() {
                <div className="text-zinc-600 text-sm lg:text-md font-semibold text-center" style={{ wordBreak: 'keep-all', whiteSpace: 'normal', lineHeight: '1.3' }}>{category.name}</div>
               </div>
            ))}
-              </div>
+           
+          
+         </div>
+        
+       </div>
+         {/* 우측 화살표 */}
+         <div className="flex items-center justify-center w-8 h-8 pointer-events-none">
+             <svg 
+               className="w-5 h-5 text-gray-400" 
+               fill="none" 
+               stroke="currentColor" 
+               viewBox="0 0 24 24"
+               style={{
+                 animation: 'bounceRight 1.5s ease-in-out infinite'
+               }}
+             >
+               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+             </svg>
+           </div>
+       
             </div>
             </div>
             </div>

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -393,7 +393,27 @@ export default function Home() {
      {/* 카테고리 섹션 */}
      <div className="flex flex-wrap gap-4 lg:gap-6 justify-center items-center w-full bg-blue-bright py-8 lg:h-68 shadow-md px-4 lg:px-0">
        <div className="flex flex-col justify-center gap-2 items-center max-w-[60rem] mx-auto">
-       <span className="text-black text-2xl font-bold mr-auto">어떤 아이디어/프로젝트가 필요하세요?</span>
+       <div className="flex items-center justify-between w-full">
+         <span className="text-black text-2xl font-bold">어떤 아이디어/프로젝트가 필요하세요?</span>
+         <div className="flex items-center gap-2">
+           <span className="text-gray-700 text-sm font-light">좌우로 슬라이드해보세요</span>
+           <div className="flex items-center gap-1">
+             
+             {/* 우측 화살표 */}
+             <svg 
+               className="w-4 h-4 text-gray-500" 
+               fill="none" 
+               stroke="currentColor" 
+               viewBox="0 0 24 24"
+               style={{
+                 animation: 'bounceRight 1.5s ease-in-out infinite'
+               }}
+             >
+               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+             </svg>
+           </div>
+         </div>
+       </div>
        <div className="w-full overflow-x-auto py-4 scrollbar-hide mt-4">
          <div className="flex gap-1 items-center" style={{ width: 'max-content' }}>
            {Array.isArray(categoryItems) && categoryItems.map((category) => (

--- a/src/pages/recruit.jsx
+++ b/src/pages/recruit.jsx
@@ -307,8 +307,6 @@ export default function Recruit() {
       <PageHeader
         leftButtons={[
           { text: "외주 조회", onClick: () => {} },
-          { text: "이 가격에 해주세요", onClick: () => {} },
-          { text: "견적 내어주세요", onClick: () => {} }
         ]}
         showDropdown={true}
         showSearchBar={true}

--- a/src/pages/recruitUpload.jsx
+++ b/src/pages/recruitUpload.jsx
@@ -368,19 +368,24 @@ export default function RecruitUpload() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    e.stopPropagation();
+
+    // 로딩 중이면 중복 실행 방지
+    if (isLoading) {
+      return;
+    }
+
+    // 카테고리 검증 (업로드 버튼 클릭 시에만 실행)
+    const cleanedCategories = filterEmptyCategories(formData.categoryDtos);
+    
+    if (cleanedCategories.length === 0) {
+      alert("최소 1개 이상의 카테고리를 선택해주세요.");
+      return;
+    }
 
     setIsLoading(true);
 
     try {
-      // 카테고리 검증
-      const cleanedCategories = filterEmptyCategories(formData.categoryDtos);
-      if (cleanedCategories.length === 0) {
-        alert("최소 1개 이상의 카테고리를 선택해주세요.");
-        setIsLoading(false);
-        return;
-      }
-
-      console.log('Selected categories:', cleanedCategories);
 
       let cityId = null;
       let cityDetailId = null;
@@ -412,6 +417,7 @@ export default function RecruitUpload() {
         price: `${formData.price}만원`,
         preferentialTreatment: formData.hasPreference ? formData.preferentialTreatment : '',
         categoryDtos: cleanedCategories,
+        // existingImageUrls: [],
         originalFileNames: formData.files.map((file) => file.name),
         workType: formData.workType.toUpperCase(),
       };
@@ -463,9 +469,9 @@ export default function RecruitUpload() {
         response = await uploadRecruit(formDataToSend);
         const { recruitId, dtoList } = response.data.result;
         
-        console.log("📦 dtoList:", dtoList);
+        // console.log("📦 dtoList:", dtoList);
 dtoList.forEach((dto, i) => {
-  console.log(`🧾 파일 ${i + 1} presignedUrl:`, dto.presignedUrl);
+  // console.log(`🧾 파일 ${i + 1} presignedUrl:`, dto.presignedUrl);
 });
 
         // 2. 파일이 있는 경우 S3 업로드 및 미디어 정보 저장
@@ -931,7 +937,7 @@ dtoList.forEach((dto, i) => {
         </div>
 
         <div>
-            <div className="flex items-center gap-2 mb-4">
+            {/* <div className="flex items-center gap-2 mb-4">
               <label className="text-xl font-semibold text-black">
                 우대사항 키워드 (2개)
           </label>
@@ -956,7 +962,7 @@ dtoList.forEach((dto, i) => {
                 placeholder="우대사항 키워드 2"
                 maxLength="10"
               />
-            </div>
+            </div> */}
           </div>
           
           <div>

--- a/src/pages/withdraw.jsx
+++ b/src/pages/withdraw.jsx
@@ -22,8 +22,8 @@ export default function Withdraw() {
 
   //bg-yellow-main 
   return (
-    <div className="min-h-screen py-24 px-52 flex flex-col items-center justify-center w-full">
-      <div className=" flex flex-col items-center justify-center bg-white rounded-2xl shadow-md p-20 w-full  text-center border border-yellow-400">
+    <div className="bg-blue-bright min-h-screen py-24 px-52 flex flex-col items-center justify-center w-full">
+      <div className=" flex flex-col items-center justify-center bg-white rounded-2xl shadow-md p-20 w-full  text-center border border-blue-400">
         {step === 1  && <WithdrawDescription
         onWithdraw={() => setStep(2)}/>}
         {step === 2  && <WithdrawalConfirm/>}


### PR DESCRIPTION


## 🛠️ 작업 내용

> 여러 디자인 요소를 수정했습니다. 이미지는 모두 수정 후 스크린샷입니다.

- 회원 탈퇴 UI에서 기존 메인 컬러 노란색을 새로 바뀐 메인 컬러 파란색 계열로 변경
<img width="813" height="451" alt="스크린샷 2025-10-01 오후 6 01 16" src="https://github.com/user-attachments/assets/c2efe29b-67f1-4a37-bbe4-4b6edc543ce2" />

- 학생 계정이 외주 등록을 클릭 시 뜨는 모달 문구 변경
<img width="807" height="439" alt="스크린샷 2025-10-01 오후 6 03 24" src="https://github.com/user-attachments/assets/625e8cbf-5d51-4ce9-aa65-4bf235e27d2c" />

- 메인 페이지 카테고리 중분류 리스트 부분 슬라이드가 가능해보이게 UI 수정 
<img width="390" height="99" alt="스크린샷 2025-10-01 오후 7 02 47" src="https://github.com/user-attachments/assets/98cff1a6-ae5a-48e7-827b-17735976b031" />
(양 옆 화살표 이미지에 애니메이션을 넣어 버튼으로 오해하지 않도록 유도)

- 외주 리스트 요소의 오른쪽(금액, 마감일)란 UI 수정
<img width="600" height="282" alt="스크린샷 2025-10-01 오후 6 14 51" src="https://github.com/user-attachments/assets/41697b78-abc0-4d9a-83e7-9df5d852c4b7" />

- 스프 AI 추천 호버링 효과(그림자)
<img width="607" height="193" alt="스크린샷 2025-10-01 오후 6 17 37" src="https://github.com/user-attachments/assets/f683cd8c-e6a4-4f97-8cb1-74c410056adf" />


- 대학생 피드 중 작성된 피드가 없을 때 스프 로고 사진 삭제
<img width="643" height="219" alt="스크린샷 2025-10-01 오후 6 25 53" src="https://github.com/user-attachments/assets/780dbbe9-6943-4b91-97ec-07f8fdef50eb" />

- 외주 찾기 페이지 `pageheader`의 문구 일부 삭제( '이 가격에 해주세요', '견적 내어주세요' )

<img width="760" height="139" alt="스크린샷 2025-10-01 오후 6 26 42" src="https://github.com/user-attachments/assets/6064deee-18e7-4e92-a090-4b4b5c3362d9" />



