### PR TITLE
FIX : 외주 업로드 이미지가 없는 경우 처리

### DIFF
--- a/src/pages/recruitUpload.jsx
+++ b/src/pages/recruitUpload.jsx
@@ -430,8 +430,8 @@ export default function RecruitUpload() {
         preferentialTreatmentTags: preferentialTreatmentTags,
         categoryDtos: cleanedCategories,
         workType: formData.workType.toUpperCase(),
-        ...(formData.newFiles.length > 0 && { originalFileNames: formData.newFiles.map((file) => file.name) }),
-        ...(formData.existingImages.length > 0 && { existingImageUrls: formData.existingImages.map((file) => file.fileUrl) }),
+        originalFileNames: formData.newFiles.map((file) => file.name),
+        existingImageUrls: formData.existingImages.map((file) => file.fileUrl),
       };
   
       


### PR DESCRIPTION
## 작업 내용
> 외주 업로드에서 이미지가 없는 경우 빈 배열로 전송하도록 코드를 변경했습니다.