### PR TITLE
REFACTOR : 리프레시 토큰 발급& 로그아웃 로직 개선 및 API 호출 코드 수정

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -17,14 +17,115 @@ let failedQueue = [];
 
 const processQueue = (error, token = null) => {
   failedQueue.forEach(prom => {
-    if (error) {
-      prom.reject(error);
-    } else {
-      prom.resolve(token);
-    }
+    error ? prom.reject(error) : prom.resolve(token);
   });
-  
   failedQueue = [];
+};
+
+// 헤더에서 AccessToken 추출
+const extractTokenFromHeaders = (headers) => {
+  return headers['new-access-token'] || 
+         headers['New-Access-Token'] || 
+         headers['X-New-Access-Token'];
+};
+
+// 응답에서 AccessToken 추출
+const extractTokenFromResponse = (response) => {
+  return response.data?.result?.accessToken || 
+         response.data?.accessToken ||
+         extractTokenFromHeaders(response.headers);
+};
+
+// 토큰 저장
+const saveTokens = (accessToken, refreshToken = null) => {
+  UserStore.getState().updateAccessToken(accessToken);
+  localStorage.setItem("accessToken", accessToken);
+  if (refreshToken) {
+    localStorage.setItem("refreshToken", refreshToken);
+  }
+};
+
+// 쿠키 삭제 헬퍼 함수
+const deleteCookie = (name) => {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=${window.location.hostname};`;
+};
+
+// 강제 로그아웃 처리 (refresh 실패 시)
+const handleRefreshFailure = async () => {
+  try {
+    // 1. 로그아웃 API 호출 (204 응답 확인)
+    const logoutResponse = await axios.post(
+      `${SERVER_URL}/api/v1/auth/logout`,
+      {},
+      { withCredentials: true, headers: { "Content-Type": "application/json" } }
+    );
+    
+    // 204 응답 확인
+    if (logoutResponse.status === 204) {
+      // console.log("로그아웃 API 호출 성공 (204)");
+    } else {
+      console.warn("로그아웃 API 응답 코드:", logoutResponse.status);
+    }
+  } catch (logoutError) {
+    // 로그아웃 API 실패해도 클라이언트 토큰은 정리
+    console.error("로그아웃 API 호출 실패:", logoutError);
+  } finally {
+    // 2. 클라이언트에서 토큰 정리
+    UserStore.getState().logout();
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+    
+    // 3. 쿠키에서 RT 삭제 (일반적인 쿠키 이름들 시도)
+    deleteCookie("refreshToken");
+    deleteCookie("RefreshToken");
+    deleteCookie("refresh_token");
+    
+    // 4. 로그인 만료 모달 표시를 위한 커스텀 이벤트 발생
+    const event = new CustomEvent('showSessionExpiredModal', {
+      detail: {
+        message: "로그인 시간이 만료되었습니다. 재로그인해주세요"
+      }
+    });
+    window.dispatchEvent(event);
+    
+    // 5. 로그인 페이지로 리다이렉트 (모달 닫힌 후 이동)
+    // 모달에서 처리하도록 주석 처리
+    // if (!window.location.pathname.includes('/login')) {
+    //   window.location.href = '/login';
+    // }
+  }
+};
+
+// 토큰 재발급 API 호출
+const refreshAccessToken = async () => {
+  const refreshToken = localStorage.getItem("refreshToken");
+  // console.log("refresh API 호출:", `${SERVER_URL}/api/v1/auth/refresh`);
+  // console.log("refreshToken 존재:", !!refreshToken);
+  
+  const response = await axios.post(
+    `${SERVER_URL}/api/v1/auth/refresh`,
+    refreshToken ? { refreshToken } : {},
+    { withCredentials: true, headers: { "Content-Type": "application/json" } }
+  );
+  
+  // console.log("refresh API 응답:", response.status, response.data);
+  
+  const newAccessToken = extractTokenFromResponse(response);
+  if (!newAccessToken) {
+    throw new Error("토큰 재발급 응답에 새 토큰이 없습니다");
+  }
+  
+  const newRefreshToken = response.data?.result?.refreshToken || response.data?.refreshToken;
+  saveTokens(newAccessToken, newRefreshToken);
+  
+  return newAccessToken;
+};
+
+// 요청에 토큰 적용 및 재시도
+const retryRequest = (request, token) => {
+  request.headers.Authorization = `Bearer ${token}`;
+  return client(request);
 };
 
 // 요청 인터셉터 추가
@@ -32,11 +133,11 @@ client.interceptors.request.use(
   (config) => {
     //const { accessToken } = UserStore.getState();
     const accessToken = localStorage.getItem("accessToken");
-    // console.log("🔑 요청 인터셉터 - 현재 액세스 토큰:", accessToken);
+    // console.log("요청 인터셉터 - 현재 액세스 토큰:", accessToken);
     
     if (accessToken) {
       config.headers.set("Authorization", `Bearer ${accessToken}`);
-      // console.log("✅ Authorization 헤더 설정됨:", `Bearer ${accessToken.substring(0, 20)}...`);
+      // console.log("Authorization 헤더 설정됨:", `Bearer ${accessToken.substring(0, 20)}...`);
     } else {
       console.log("❌ 액세스 토큰이 없음");
     }
@@ -55,33 +156,75 @@ client.interceptors.response.use(
     const status = error.response?.status;
     const message = error.response?.data?.message;
 
-    console.log("응답 인터셉터 - 에러 상태:", status);
-    console.log("응답 인터셉터 - 에러 URL:", originalRequest?.url);
+    // console.log("응답 인터셉터 - 에러 상태:", status);
+    // console.log("응답 인터셉터 - 에러 URL:", originalRequest?.url);
 
-    if ((status === 403 || status === 401) && !originalRequest._retry) {
+    // 401 에러 발생 시 토큰 재발급 시도
+    if (status === 401 && !originalRequest._retry) {
+      const requestUrl = originalRequest.url || originalRequest._fullUrl || '';
+      // console.log("401 에러 - 요청 URL:", requestUrl);
+      
+      // refresh API 호출 자체가 실패한 경우 (RT가 유효하지 않음)
+      if (requestUrl.includes('/api/v1/auth/refresh')) {
+        // console.log("refresh API 자체가 401 에러 발생 - 로그아웃 처리");
+        await handleRefreshFailure();
+        return Promise.reject(error);
+      }
+
+      // console.log("401 에러 발생 - 토큰 재발급 시도 시작");
       originalRequest._retry = true;
 
       // 1. 헤더에 새 토큰이 포함된 경우
-      const newAccessToken =
-        error.response.headers['new-access-token'] ||
-        error.response.headers['New-Access-Token'] ||
-        error.response.headers['X-New-Access-Token'];
+      const headerToken = extractTokenFromHeaders(error.response?.headers);
+      if (headerToken) {
+        // console.log("헤더에서 새 토큰 발견");
+        saveTokens(headerToken);
+        return retryRequest(originalRequest, headerToken).catch(err => {
+          console.error("재시도 요청 실패:", err);
+          return Promise.reject(err);
+        });
+      }
 
-      if (newAccessToken) {
-        console.log("응답 헤더에서 새 토큰 발견, 재시도");
-
-        UserStore.getState().updateAccessToken(newAccessToken);
-        localStorage.setItem("accessToken", newAccessToken);
-
-        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+      // 2. refresh API 호출
+      if (!isRefreshing) {
+        isRefreshing = true;
+        // console.log("refresh API 호출 시작");
         try {
-          return await client(originalRequest); 
-        } catch (retryError) {
-          console.error("🔁 재시도 요청 실패:", retryError);
-          return Promise.reject(retryError); 
+          const newAccessToken = await refreshAccessToken();
+          // console.log("토큰 재발급 성공");
+          processQueue(null, newAccessToken);
+          return retryRequest(originalRequest, newAccessToken);
+        } catch (refreshError) {
+          console.error("❌ 토큰 재발급 실패:", refreshError);
+          processQueue(refreshError, null);
+          // refresh 실패 시 로그아웃 처리
+          await handleRefreshFailure();
+          return Promise.reject(refreshError);
+        } finally {
+          isRefreshing = false;
         }
+      } else {
+        // 이미 재발급 중인 경우 대기
+        // console.log("이미 토큰 재발급 진행 중 - 대기");
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        }).then(token => retryRequest(originalRequest, token));
       }
     }
+
+    // 403 에러 처리 (기존 로직 유지)
+    if (status === 403 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      const headerToken = extractTokenFromHeaders(error.response?.headers);
+      if (headerToken) {
+        saveTokens(headerToken);
+        return retryRequest(originalRequest, headerToken).catch(err => {
+          console.error("🔁 재시도 요청 실패:", err);
+          return Promise.reject(err);
+        });
+      }
+    }
+
     // AlertModal이 있는 페이지는 에러 페이지로 이동하지 않고 모달이 뜨게
     // if (status === 403) {
     //   if (!window.location.pathname.includes("/recruitDetails")) {

--- a/src/api/inquiry.js
+++ b/src/api/inquiry.js
@@ -4,6 +4,7 @@ import axios from "axios";
 export const postInquiry = async (requestBody) => {
     try {
         const response = await client.post("/api/v1/inquiry", requestBody);
+        console.log(response);
         return response.data;
     } catch (error) {
         console.error("문의 생성 에러:", error);
@@ -26,30 +27,19 @@ export async function getInquiryList(pageable) {
     const accessToken = localStorage.getItem("accessToken");
     const response = await client.get("/api/v1/inquiry/my", {
       params: pageable,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
     });
     return response;
   }
   
   export async function deleteInquiry(inquiryId) {
     const accessToken = localStorage.getItem("accessToken");
-    const response = await client.delete(`/api/v1/inquiry/${inquiryId}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await client.delete(`/api/v1/inquiry/${inquiryId}`);
     return response;
   }
   
   export async function patchInquiry(inquiryId, requestBody) {
     const accessToken = localStorage.getItem("accessToken");
-    const response = await client.patch(`/api/v1/inquiry/${inquiryId}`, requestBody, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await client.patch(`/api/v1/inquiry/${inquiryId}`, requestBody);
     return response;
   }
 

--- a/src/api/mypage.js
+++ b/src/api/mypage.js
@@ -10,19 +10,13 @@ export const uploadToS3 = async (url, file) => {
 
 /* 1. 프로필 정보 + 새 파일명 전송 (Presigned URL 반환 기대) */
 export async function updateProfileInfo(data) {
-  const accessToken = localStorage.getItem("accessToken");
   const response = await client.put("/api/v1/member/update", data, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
   });
   return response.data;
 }
 
 /* 2. S3 업로드 후, 이미지 정보 최종 전송 */
 export async function confirmImageUpload({ postId, fileUrl, fileName, fileType }) {
-    const accessToken = localStorage.getItem("accessToken");
     const requestData = {
       postId,
       fileUrl:  Array.isArray(fileUrl) ? fileUrl : [fileUrl],
@@ -36,12 +30,6 @@ export async function confirmImageUpload({ postId, fileUrl, fileName, fileType }
 
     const response = await client.post("/api/v1/member/upload", 
         requestData, 
-        {
-            headers: {
-                Authorization: `Bearer ${accessToken}`,
-                "Content-Type": "application/json",
-            },
-        }
     );
     console.log(response);
     return response.data;
@@ -49,12 +37,7 @@ export async function confirmImageUpload({ postId, fileUrl, fileName, fileType }
 
 /* 프로필 조회 */
 export async function getProfile() {
-  const accessToken = localStorage.getItem("accessToken");
-  const response = await client.get("/api/v1/member/myinfo", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
+  const response = await client.get("/api/v1/member/myinfo");
   // console.log(response);
   return response;
 }
@@ -87,9 +70,6 @@ export async function getInquiryList(pageable) {
   const accessToken = localStorage.getItem("accessToken");
   const response = await client.get("/api/v1/inquiry/my", {
     params: pageable,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
   });
   return response;
 }
@@ -97,9 +77,6 @@ export async function getInquiryList(pageable) {
 export async function deleteInquiry(inquiryId) {
   const accessToken = localStorage.getItem("accessToken");
   const response = await client.delete(`/api/v1/inquiry/${inquiryId}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
   });
   return response;
 }

--- a/src/api/recruit.js
+++ b/src/api/recruit.js
@@ -12,6 +12,7 @@ export const getPopularRecruit = async () => {
 };
 
 export async function getRecruit(params = {}) {
+
     try {
         const {
             firstCategory,
@@ -72,17 +73,13 @@ export async function getRecruit(params = {}) {
                 categories: categories,
                 sortOption: sortOption
         };
-        // 토큰 확인
-        const token = localStorage.getItem('accessToken');
+      
         const response = await client.post('/api/v1/recruit/search', requestBody, {
             params: {
                 page: page,
                 size: size,
             },
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
+          
         });
           
         return response;
@@ -98,34 +95,29 @@ export async function getRecruitDetail(recruitId) {
         const token = localStorage.getItem('accessToken');
         const url = `/api/v1/recruit/${recruitId}`;
      
-        const response = await client.get(url, {
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
-        });
+        const response = await client.get(url);
         
         // console.log("API Response:", response);
         return response;
     } catch (error) {
-        console.error('Recruit Detail API 오류 발생:', error);
-        console.error('Error response:', error.response);
-        console.error('Error status:', error.response?.status);
-        console.error('Error data:', error.response?.data);
+        // console.error('Recruit Detail API 오류 발생:', error);
+        // console.error('Error response:', error.response);
+        // console.error('Error status:', error.response?.status);
+        // console.error('Error data:', error.response?.data);
         
-        if (error.response?.status === 403) {
-            console.error('403 Forbidden - 권한이 없습니다.');
-            console.error('Response data:', error.response.data);
+        // if (error.response?.status === 403) {
+        //     console.error('403 Forbidden - 권한이 없습니다.');
+        //     console.error('Response data:', error.response.data);
             
-            // 토큰이 만료되었거나 유효하지 않은 경우
-            if (error.response.data?.message?.includes('token') || 
-                error.response.data?.message?.includes('unauthorized')) {
-                console.log('토큰이 만료되었습니다. 로그인 페이지로 이동합니다.');
-                localStorage.removeItem('accessToken');
-                window.location.href = '/login';
-                return;
-            }
-        }
+        //     // 토큰이 만료되었거나 유효하지 않은 경우
+        //     if (error.response.data?.message?.includes('token') || 
+        //         error.response.data?.message?.includes('unauthorized')) {
+        //         console.log('토큰이 만료되었습니다. 로그인 페이지로 이동합니다.');
+        //         localStorage.removeItem('accessToken');
+        //         window.location.href = '/login';
+        //         return;
+        //     }
+        // }
         
         throw error;
     }
@@ -133,12 +125,7 @@ export async function getRecruitDetail(recruitId) {
 
 export async function uploadRecruit(data) {
     try {
-        const response = await client.post('/api/v1/recruit', data, {
-            headers: {
-                'Authorization': `Bearer ${localStorage.getItem('accessToken')}`,
-                'Content-Type': 'application/json'
-            }
-        });
+        const response = await client.post('/api/v1/recruit', data);
         return response;
     } catch (error) {
         console.error('Recruit Upload API 오류 발생:', error);
@@ -149,12 +136,7 @@ export async function uploadRecruit(data) {
 export async function updateRecruit(recruitId, data) {
     // console.log("data", data);
     try {
-        const response = await client.patch(`/api/v1/recruit/${recruitId}`, data, {
-            headers: {
-                'Authorization': `Bearer ${localStorage.getItem('accessToken')}`,
-                'Content-Type': 'application/json'
-            }
-        });
+        const response = await client.patch(`/api/v1/recruit/${recruitId}`, data);
         return response;
     } catch (error) {
         console.error('Recruit Update API 오류 발생:', error);
@@ -243,11 +225,6 @@ export async function closeRecruit(recruitId, memberId) {
     try {
         const response = await client.patch(`/api/v1/recruit/closure/${recruitId}`, {
             memberId: memberId
-        }, {
-            headers: {
-                'Authorization': `Bearer ${localStorage.getItem('accessToken')}`,
-                'Content-Type': 'application/json'
-            }
         });
         return response;
     } catch (error) {

--- a/src/components/studentProfile/profile.jsx
+++ b/src/components/studentProfile/profile.jsx
@@ -45,10 +45,6 @@ export default function Profile({
   };
 
   const clickHandler = (memberId) => {
-    if (!currentMemberId) {
-      setShowLoginModal(true);
-      return;
-    }
     navigate(`/profileDetail/${memberId}`);
   };
 
@@ -62,7 +58,7 @@ export default function Profile({
       
       <div className="w-full flex items-center justify-start gap-8"
       onClick={() => clickHandler(memberId)}>
-        <div className="flex flex-col items-center justify-center border-r border-gray-200 pr-8">
+        <div className="flex flex-col items-center justify-center border-r border-gray-200 pr-8 ">
         <img 
           src={profileImageUrl || getDefaultImage()} 
           className="rounded-full min-w-24 h-24 border border-gray-200 " 
@@ -96,7 +92,7 @@ export default function Profile({
           </div>
         )}
       </div>
-      
+{/*       
       {showLoginModal && (
         <AlertModal
           type="simple"
@@ -110,7 +106,7 @@ export default function Profile({
           }}
           onClickFalse={() => setShowLoginModal(false)}
         />
-      )}
+      )} */}
     </div>
   );
 }

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -36,6 +36,11 @@ export default function Login() {
 
       UserStore.getState().setAccessToken(result.accessToken);
       localStorage.setItem("accessToken", result.accessToken);
+      
+      // RefreshToken 저장 (응답에 포함된 경우)
+      if (result.refreshToken) {
+        localStorage.setItem("refreshToken", result.refreshToken);
+      }
 
       navigate("/");
     },

--- a/src/pages/recruitDetails.jsx
+++ b/src/pages/recruitDetails.jsx
@@ -31,10 +31,8 @@ export default function RecruitDetail() {
   const recruitData = location.state;
   const [recruitDetail, setRecruitDetail] = useState(null);
   const [showMenu, setShowMenu] = useState(false);
-  const { username, memberId, approvedStatus } = UserStore();
-  const [isApplyModalOpen, setIsApplyModalOpen] = useState(false);
-  const [isApplySuccessModalOpen, setIsApplySuccessModalOpen] = useState(false);
-  const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
+  const { username, memberId, approvedStatus, roleType } = UserStore();
+  const [modal, setModal] = useState(null);
   const [isCloseSuccessModalOpen, setIsCloseSuccessModalOpen] = useState(false);
   const [isAlreadyClosedModalOpen, setIsAlreadyClosedModalOpen] = useState(false);
   const [isEstimateModalOpen, setIsEstimateModalOpen] = useState(false);
@@ -136,7 +134,15 @@ export default function RecruitDetail() {
       setShowMenu(false);
     } else {
       // 마감 가능한 경우
-      setIsCloseModalOpen(true);
+      setModal({
+        type: 'warning',
+        title: '지원 마감',
+        description: '해당 공고문을 지원 마감 상태로 바꾸시겠습니까? ',
+        FalseBtnText: '취소',
+        TrueBtnText: '지원 마감',
+        onClickFalse: () => setModal(null),
+        onClickTrue: handleCloseRecruit,
+      });
       setShowMenu(false);
     }
   };
@@ -144,7 +150,7 @@ export default function RecruitDetail() {
   const handleCloseRecruit = async () => {
     try {
       await closeRecruit(id, memberId);
-      setIsCloseModalOpen(false);
+      setModal(null);
       setIsCloseSuccessModalOpen(true);
     } catch (error) {
       console.error('지원 마감 실패:', error);
@@ -156,6 +162,19 @@ export default function RecruitDetail() {
 
   const handleApply = () => {
     // console.log('지원 버튼 클릭');
+    
+    // 학생 계정인지 확인
+    if (roleType !== "STUDENT") {
+      setModal({
+        type: 'simple',
+        title: '지원 불가',
+        description: '학생 계정만 지원 기능을 이용할 수 있습니다.',
+        TrueBtnText: '확인',
+        onClickTrue: () => setModal(null),
+      });
+      return;
+    }
+    
     if (approvedStatus === "PENDING") {
       setErrorDescription("승인 대기 중인 유저는\n지원할 수 없습니다.");
       setErrorAction("redirect");
@@ -165,7 +184,15 @@ export default function RecruitDetail() {
     if (!displayData?.price || displayData.price === '견적 희망') {
       setIsEstimateModalOpen(true);
     } else {
-      setIsApplyModalOpen(true);
+      setModal({
+        type: 'warning',
+        title: '해당 기업에 지원하시겠습니까?',
+        description: '지원 시 내 프로필 정보가 기업에게 전송됩니다.\n마이페이지에서 지원 취소가 가능합니다.\n지원 직후에는, 기업에게 지원 알림이 전송됩니다.',
+        FalseBtnText: '취소',
+        TrueBtnText: '지원',
+        onClickFalse: () => setModal(null),
+        onClickTrue: handleApplyTrue,
+      });
     }
   };
 
@@ -181,8 +208,14 @@ export default function RecruitDetail() {
        priceReason: priceReason,
       });
       // console.log("지원 성공:", response.data);
-      setIsApplyModalOpen(false);
-      setIsApplySuccessModalOpen(true);
+      setModal(null);
+      setModal({
+        type: 'success',
+        title: '지원 완료',
+        description: '지원이 완료되었습니다.',
+        TrueBtnText: '확인',
+        onClickTrue: () => setModal(null),
+      });
     } catch (error) {
       console.error("지원 실패:", error);
       // if (error.response?.status === 403) {
@@ -215,7 +248,13 @@ export default function RecruitDetail() {
       });
       // console.log("견적 제출 성공:", response.data);
       setIsEstimateModalOpen(false);
-      setIsApplySuccessModalOpen(true);
+      setModal({
+        type: 'success',
+        title: '지원 완료',
+        description: '지원이 완료되었습니다.',
+        TrueBtnText: '확인',
+        onClickTrue: () => setModal(null),
+      });
 
       setPriceOffer('');
       setPriceReason('');
@@ -525,41 +564,15 @@ export default function RecruitDetail() {
           )}
           <span className="text-zinc-500">이 외주를 총 <span className="text-black font-bold">{displayData?.totalViewCount}</span>명이 조회하였습니다.</span>
           </div>
-  {isApplyModalOpen && (
+      {modal && (
         <AlertModal
-          type="warning"
-          isOpen={isApplyModalOpen}
-          onClose={() => setIsApplyModalOpen(false)}
-          title="해당 기업에 지원하시겠습니까?"
-          description={`지원 시 내 프로필 정보가 기업에게 전송됩니다.\n마이페이지에서 지원 취소가 가능합니다.\n지원 직후에는, 기업에게 지원 알림이 전송됩니다.`}
-          FalseBtnText = "취소"
-          TrueBtnText = "지원"
-          onClickFalse={() => setIsApplyModalOpen(false)}
-          onClickTrue={handleApplyTrue}
-        />
-      )}
-      {isApplySuccessModalOpen && (
-        <AlertModal
-          type="success"
-          isOpen={isApplySuccessModalOpen}
-          onClose={() => setIsApplySuccessModalOpen(false)}
-          title="지원 완료"
-          description="지원이 완료되었습니다."
-          TrueBtnText = "확인"
-          onClickTrue={() => setIsApplySuccessModalOpen(false)}
-        />
-      )}
-      {isCloseModalOpen && (
-        <AlertModal
-          type="warning"
-          isOpen={isCloseModalOpen}
-          onClose={() => setIsCloseModalOpen(false)}
-          title="지원 마감"
-          description="해당 공고문을 지원 마감 상태로 바꾸시겠습니까? "
-          FalseBtnText = "취소"
-          TrueBtnText = "지원 마감"
-          onClickFalse={() => setIsCloseModalOpen(false)}
-          onClickTrue={handleCloseRecruit}
+          type={modal.type}
+          title={modal.title}
+          description={modal.description}
+          FalseBtnText={modal.FalseBtnText}
+          TrueBtnText={modal.TrueBtnText}
+          onClickFalse={modal.onClickFalse}
+          onClickTrue={modal.onClickTrue}
         />
       )}
       {isCloseSuccessModalOpen && (

--- a/src/pages/redirect.jsx
+++ b/src/pages/redirect.jsx
@@ -101,6 +101,12 @@ export default function Redirect() {
               });
               UserStore.getState().setAccessToken(result.token.accessToken);
               localStorage.setItem("accessToken", result.token.accessToken);
+              
+              // RefreshToken 저장 (응답에 포함된 경우)
+              if (result.token.refreshToken || result.refreshToken) {
+                localStorage.setItem("refreshToken", result.token.refreshToken || result.refreshToken);
+              }
+              
               localStorage.removeItem('socialProvider');
               
               navigate("/");
@@ -115,7 +121,7 @@ export default function Redirect() {
                   provider: detectedProvider || {},
                   email: result.prefill.email || {},
                   username: result.prefill.name || {},
-                  registrationToken: result.message,
+                  registrationToken: result.registrationToken,
                 },
               });
             }

--- a/src/router/router.jsx
+++ b/src/router/router.jsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation, useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
 import Header from "../components/header";
 import Home from "../pages/home";
 import Login from "../pages/login";
@@ -31,9 +32,26 @@ import ReviewDetail from "../pages/reviewDetail";
 import Inspection from "../pages/inspection";
 import { HelmetProvider } from 'react-helmet-async';
 import FloatingChatButton from "../components/floatingChatButton";
+import AlertModal from "../components/alertModal";
+
 function AppRouter() {
   const location = useLocation();
+  const navigate = useNavigate();
   const isChatPage = location.pathname === "/chat";
+  const [showSessionExpiredModal, setShowSessionExpiredModal] = useState(false);
+
+  useEffect(() => {
+    // 세션 만료 이벤트 리스너
+    const handleSessionExpired = (event) => {
+      setShowSessionExpiredModal(true);
+    };
+
+    window.addEventListener('showSessionExpiredModal', handleSessionExpired);
+
+    return () => {
+      window.removeEventListener('showSessionExpiredModal', handleSessionExpired);
+    };
+  }, []);
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -73,6 +91,22 @@ function AppRouter() {
       </main>
       {!isChatPage && <Footer />}
       {!isChatPage && <FloatingChatButton />}
+      
+      {/* 세션 만료 모달 */}
+      {showSessionExpiredModal && (
+        <AlertModal
+          type="simple"
+          title="로그인 만료"
+          description="로그인 시간이 만료되었습니다. 재로그인해주세요"
+          TrueBtnText="로그인하러 가기"
+          onClickTrue={() => {
+            setShowSessionExpiredModal(false);
+            if (!location.pathname.includes('/login')) {
+              navigate('/login');
+            }
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION

## 🛠️ 작업 내용

> AccessToken 유효성 검사와 RefreshToken 재발급 문제 해결

1. AccessToken에 대해서만 유효성 검사를 실행
2. AccessToken에 대한 유효성 검사에 실패하거나(401에러), AccessToken이 없을 시 `/api/v1/auth/refresh` 호출 (토큰 재발급)
3. 토큰 재발급 API 호출 에러 시, RefreshToken가 유효하지 않다는 의미이므로 강제 로그아웃+재로그인 유도
4. `/api/v1/auth/logout`를 호출하면서 캐시 저장소에 저장되어 있는 AccessToken과 RefreshToken에 대한 모든 정보를 지우기 때문에 클라이언트에서도 헤더와 쿠키에서 지움.

(추가)
API 연결 시 직접 헤더(AccessToken)를 설정한 코드 전부 수정



