### PR TITLE
FEAT : 이용약관&개인정보처리방침&분쟁처리방침 페이지 구현

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -34,7 +34,7 @@ export default function Footer() {
           <p>개인정보 관리자 : 박정곤</p>
        
         </div>
-        <p className="text-neutral-400 text-md">해당 사이트에서 판매되는 모든 상품에 대한 환불 및 모든 민원의 책임은 스프에 있습니다.</p>
+        {/* <p className="text-neutral-400 text-md">해당 사이트에서 판매되는 모든 상품에 대한 환불 및 모든 민원의 책임은 스프에 있습니다.</p> */}
 
        </div>
 
@@ -44,28 +44,28 @@ export default function Footer() {
         <div className="flex gap-10 font-semibold text-md w-full text-gray-500">
           <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
-            onClick={navigate('/policy/page1')}
+            onClick={() => navigate('/policy/terms')}
           >
             이용약관
           </div>
           
           <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
-            onClick={() => window.open('https://www.notion.so/293adbfeb0858054beecca8fe3d2e5cf?source=copy_link', '_blank')}
+            onClick={() => navigate('/policy/privacy')}
           >
             개인정보처리방침
           </div>
           
-          <div 
+          {/* <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
             onClick={() => window.open('https://www.notion.so/SouF-293adbfeb08580eda58dec894c1c9463?source=copy_link', '_blank')}
           >
           결제·정산·환불(에스크로) 정책
-          </div>
+          </div> */}
           
           <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
-            onClick={() => window.open('https://www.notion.so/SouF-293adbfeb08580b59ce9c871ba2f2fb3?source=copy_link', '_blank')}
+            onClick={() => navigate('/policy/complaintDispute')}
           >
           분쟁처리방침
             </div>
@@ -84,7 +84,7 @@ export default function Footer() {
           <p>주소 : 서울특별시 광진구 광나루로19길 23, 103호</p>
           <p>개인정보 관리자 : 박정곤</p>
         </div>
-        <p className="text-neutral-400 text-md">해당 사이트에서 판매되는 모든 상품에 대한 환불 및 모든 민원의 책임은 스프에 있습니다.</p>
+        {/* <p className="text-neutral-400 text-md">해당 사이트에서 판매되는 모든 상품에 대한 환불 및 모든 민원의 책임은 스프에 있습니다.</p> */}
 
        </div>
        <div className="block md:hidden">
@@ -92,7 +92,7 @@ export default function Footer() {
         <div className="flex flex-col gap-1 font-semibold text-md w-full text-gray-500">
           <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
-            onClick={navigate('/policy/page1')}
+            onClick={() => navigate('/policy/terms')}
           >
             이용약관
             <img src={backArrow} alt="backArrow" className="w-6 h-6 rotate-180 brightness-10" />
@@ -100,23 +100,23 @@ export default function Footer() {
           
           <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
-            onClick={() => window.open('https://www.notion.so/293adbfeb0858054beecca8fe3d2e5cf?source=copy_link', '_blank')}
+            onClick={() => navigate('/policy/privacy')}
           >
             개인정보처리방침
             <img src={backArrow} alt="backArrow" className="w-6 h-6 rotate-180 brightness-10" />
           </div>
           
-          <div 
+          {/* <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
             onClick={() => window.open('https://www.notion.so/SouF-293adbfeb08580eda58dec894c1c9463?source=copy_link', '_blank')}
           >
           결제·정산·환불(에스크로) 정책
             <img src={backArrow} alt="backArrow" className="w-6 h-6 rotate-180 brightness-10" />
-          </div>
+          </div> */}
           
           <div 
             className='flex items-center gap-2 cursor-pointer hover:text-gray-700 transition-all duration-200 hover:brightness-0'
-            onClick={() => window.open('https://www.notion.so/SouF-293adbfeb08580b59ce9c871ba2f2fb3?source=copy_link', '_blank')}
+            onClick={() => navigate('/policy/complaintDispute')}
           >
           분쟁처리방침
             <img src={backArrow} alt="backArrow" className="w-6 h-6 rotate-180 brightness-10" />

--- a/src/pages/policy/complain.jsx
+++ b/src/pages/policy/complain.jsx
@@ -1,0 +1,118 @@
+export default function ComplainPage() {
+    return (
+        <div className="max-w-[60rem] w-full mx-auto px-4 mt-12 mb-20">
+            <h2 className="text-black font-bold text-4xl mb-6">분쟁처리방침</h2>
+
+            <p className="text-black text-xl pl-4">시행일자: 2025.10.19</p>
+  <p className="text-black text-xl pl-4">회사명: 스프(SouF)</p>
+  <p className="text-black text-xl pl-4">연락처: 사이트 하단 참고</p>
+
+  <div className="bg-gray-100 border-l-4 border-red-500 p-4 mt-4">
+    <p className="text-black text-xl pl-4 font-semibold">⛔️ 중요 고지</p>
+    <p className="text-black text-xl pl-4">
+      분쟁 예방과 공정한 처리를 위해 모든 거래는 <strong>스프 표준 계약서로 진행</strong>해야 합니다.
+    </p>
+    <p className="text-black text-xl pl-4">
+      해당 절차를 사용하지 않은 거래(플랫폼 외 협의·자체 계약·현금 직접지급 등)는 회사가 분쟁의 판단·중재에 관여하지 않으며, 시스템에 존재하는 사실자료의 열람·제공 범위 이외에는 지원이 어렵습니다.
+    </p>
+    {/* <p className="text-black text-xl pl-4">
+      또한 예치되지 않은 대금의 반환·정산은 보장되지 않습니다.
+    </p> */}
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">1. 목적 및 적용 범위</h3>
+  <p className="text-black text-xl pl-4">
+    본 방침은 SouF 플랫폼에서 발생할 수 있는 기업–프리랜서 간 외주 거래 분쟁 및 이용자–회사 간 서비스 분쟁을 신속·공정하게 처리하기 위한 원칙과 절차를 규정합니다. 본 방침은 이용약관, 결제·정산·환불(에스크로) 정책, 표준 외주계약서와 함께 적용됩니다.
+  </p>
+
+  
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">2. 용어의 정의</h3>
+  <div className="flex flex-col gap-4">
+    <p className="text-black text-xl pl-4">
+    이 약관에서 정하는 용어의 정의는 다음과 같습니다.
+    </p>
+  <p className="text-black text-xl pl-4">
+  ① 스프(SouF) 회사가 제공하는 서비스에 가입한 자(기업·소상공인·개인사업자·프리랜서 포함)를 회원이라 하며, 회원 중 프로젝트를 의뢰하고 대금을 지급하는 자를 발주자(수요자/의뢰자)라 하고, 프로젝트를 수행하는 자를 수급자(공급자/프리랜서/대학생 프리랜서)라 합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ② 프로젝트(외주)란 플랫폼을 통해 체결·수행되는 업무를 의미하며, 표준 계약서는 회사가 제공하는 외주 표준계약을 말합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+       ③ 검수 승인 또는 자동 승인은 결과물 승인 또는 기한 경과에 따른 승인을 말하며, 중도해지는 계약 기간 중 당사자가 계약을 해지하는 행위를 의미합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ④ 전자서명은 전자적 방식으로 서명·동의하는 행위를 의미합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ⑤ 제3자 제공 또는 처리위탁(수탁자)은 개인정보처리방침에서 쓰는 법정 용어를 의미하며, 서비스 제공기간은 결제일로부터 최대 180일을 말합니다.
+      </p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">3. 회사(플랫폼)의 역할</h3>
+  <p className="text-black text-xl pl-4">
+    회사는 매칭·표준계약서 작성 지원·계약 체결 기록 보관 기능을 제공합니다.
+  </p>
+  <p className="text-black text-xl pl-4">
+    회사는 외주 계약의 직접 당사자가 아니며, 프로젝트 이행 책임은 발주자와 수급자에게 있습니다. 분쟁 시 회사는 본 방침에 따라 조정·기록 제공 범위 내에서 지원합니다.
+  </p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">4. 분쟁 유형(예시)</h3>
+  {/* <p className="text-black text-xl pl-4">- 대금·정산: 선금/잔금 지급, 환불(예치 잔금 반환)</p> */}
+  <p className="text-black text-xl pl-4">- 이행·품질: 일정 지연, 산출물 품질·수정 횟수 이견, 검수 불합리 주장</p>
+  <p className="text-black text-xl pl-4">- 권리침해: 저작권·초상권·상표권 관련 게시물/결과물 분쟁</p>
+  <p className="text-black text-xl pl-4">- 계정·후기: 허위 후기, 모욕/비방, 부정사용</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">5. 처리 원칙</h3>
+  <p className="text-black text-xl pl-4">- 문서 우선: 표준 계약서·별첨 명세, 채팅 로그, 결제·정산 로그를 최우선 증빙으로 삼습니다.</p>
+  <p className="text-black text-xl pl-4">- 신속·중립: 정해진 기한 내 중립적으로 사실을 확인하고 합리적 조정안을 제시합니다.</p>
+  <p className="text-black text-xl pl-4">- 최소 개입: 자율 합의를 우선하며, 불가 시 정책·계약 기준으로 조정합니다.</p>
+  <p className="text-black text-xl pl-4">- 개인정보 최소화: 분쟁 처리 목적 범위 내에서만 자료를 열람·제공합니다.</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">6. 처리 절차 및 기한(SLA)</h3>
+  <p className="text-black text-xl pl-4">1. 접수: 마이페이지 › 도움말/문의 또는 고객센터로 접수 → 접수번호 발급</p>
+  <p className="text-black text-xl pl-4">2. 초기 안내(영업일 기준 3일 이내): 담당자 배정, 필요 자료 목록 안내, 임시조치 여부 통지</p>
+  <p className="text-black text-xl pl-4">3. 사실 확인(영업일 기준 7–10일 이내): 양측 소명·증빙 확인(계약/채팅/파일/정산 로그)</p>
+  <p className="text-black text-xl pl-4">4. 조정안 제시(최초 접수 후 14–30일 이내): 환불·지급·수정·비공개 등 조정안 통지</p>
+  <p className="text-black text-xl pl-4">5. 종결: 합의 또는 미합의 종결 통지. 미합의 시 외부 분쟁조정·법원 이용 안내</p>
+  <p className="text-black text-xl pl-4">※ 긴급 사안(사기·권리침해 등)은 선조치(비공개, 게시중단) 후 사실 확인을 진행할 수 있습니다.</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">7. 조정 기준(요지)</h3>
+  <p className="text-black text-xl pl-4">- 검수·수정: 계약서의 검수 기한·수정 횟수(별첨 기준) 준수 여부를 확인합니다.</p>
+  <p className="text-black text-xl pl-4">- 중도해지: 작업 진행률(마일스톤/산출물 기준)에 따라 정산 후 예치 잔금 반환/지급을 결정합니다.</p>
+  <p className="text-black text-xl pl-4">- 완료 후: 검수 승인 또는 자동 승인 이후에는 잔금 반환이 불가합니다(하자 시 재수정/보증 절차).</p>
+  <p className="text-black text-xl pl-4">- 권리침해: 소명자료와 권리관계 확인 후 임시 비공개/삭제/수정 및 재발 방지 조치.</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">8. 임시조치 및 제재</h3>
+  <p className="text-black text-xl pl-4">- 임시조치: 게시물/피드 비공개, 검색 제한, 정산 보류, 신규 거래 제한</p>
+  <p className="text-black text-xl pl-4">- 제재: 경고, 기간 제한, 영구 이용정지, 법령 위반 시 관계기관 통보</p>
+  <p className="text-black text-xl pl-4">- 임시조치·제재 사유와 이의신청 방법을 알립니다.</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">9. 증빙 제출 안내</h3>
+  <p className="text-black text-xl pl-4">- 필수: 표준 계약서 및 별첨, 채팅 로그(플랫폼 내), 산출물/납품 이력, 결제·정산 로그</p>
+  <p className="text-black text-xl pl-4">- 선택: 외부 커뮤니케이션 기록, 공문/권리증서, 기타 객관증빙</p>
+  <p className="text-black text-xl pl-4">- 형식: 스크린샷·원본 파일·링크. 위·변조가 의심되는 자료는 인정되지 않을 수 있습니다.</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">10. 표준 계약서 미사용 거래</h3>
+  <p className="text-black text-xl pl-4">- 플랫폼 표준 계약·정산 절차를 사용하지 않은 거래(외부 메신저 협의, 현금 직접지급 등)는 지원·분쟁 대응 대상에서 제외됩니다.</p>
+  <p className="text-black text-xl pl-4">- 이 경우 회사는 시스템에 존재하는 사실자료(채팅 타임스탬프, 결제/환불 이벤트 로그 등)의 열람·제공에 한하여 지원할 수 있습니다.</p>
+  {/* <p className="text-black text-xl pl-4">- 환불·정산은 KG이니시스를 통한 예치금에 한해 처리됩니다.</p> */}
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">11. 자료 보관 및 제공</h3>
+  <p className="text-black text-xl pl-4">분쟁 처리와 법령 준수를 위해 필요한 자료는 관련 법령 및 개인정보 처리방침에 따라 보관·파기하며, 사법기관·분쟁조정기구의 적법한 요청에 한해 제공될 수 있습니다.</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">12. 외부 분쟁조정 및 관할</h3>
+  <p className="text-black text-xl pl-4">- 합의에 이르지 못하거나 법적 판단이 필요한 경우, 관할·준거법은 이용약관 및 계약서 조항에 따릅니다.</p>
+  <p className="text-black text-xl pl-4">- 약관(플랫폼 ↔ 회원)</p>
+  <p className="text-black text-xl pl-6">- 본 약관 및 서비스와 관련하여 발생한 분쟁의 1심 관할은 서울중앙지방법원으로 합니다.</p>
+  <p className="text-black text-xl pl-6">- 이용자의 주소지 관할 법원도 1심 관할로 합니다.</p>
+  <p className="text-black text-xl pl-4">- 표준 외주계약(발주자 ↔ 수급자)</p>
+  <p className="text-black text-xl pl-6">- 본 계약과 관련하여 분쟁이 발생한 경우, 당사자는 우선 협의로 해결하되, 협의가 불가한 때에는 피고의 보통재판적이 있는 법원을 1심 관할로 합니다.</p>
+  <p className="text-black text-xl pl-6">- 단, 당사자 합의가 있는 경우 서울중앙지방법원을 1심 관할로 할 수 있습니다.</p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">13. 기타</h3>
+  <p className="text-black text-xl pl-4">- 본 방침에 정하지 않은 사항은 이용약관, 표준 외주계약서 및 관련 법령을 따릅니다.</p>
+  <p className="text-black text-xl pl-4">- 회사는 서비스 안전과 공정성을 위해 필요한 범위에서 본 방침을 개정할 수 있으며, 시행 7일 전 공지합니다.</p>
+        </div>
+    )
+}

--- a/src/pages/policy/page1.jsx
+++ b/src/pages/policy/page1.jsx
@@ -1,3 +1,0 @@
-export default function Page1() {
-  return <div>Page1</div>;
-}

--- a/src/pages/policy/privacy.jsx
+++ b/src/pages/policy/privacy.jsx
@@ -1,0 +1,190 @@
+export default function PrivacyPage() {
+    return (
+        <div className="max-w-[60rem] w-full mx-auto px-4 mt-12 mb-20">
+              <h2 className="text-black font-bold text-4xl mb-6">개인정보처리방침</h2>
+
+              <p className="text-black text-xl pl-4">
+              스프(이하 “회사”)는 「개인정보 보호법」 및 관련 법령을 준수하며, 이용자의 개인정보를 안전하게 처리하기 위해 다음과 같이 개인정보 처리방침을 수립·공개합니다.
+              </p>
+
+              <h3 className="text-black font-semibold text-3xl mb-6 mt-10">1. 처리의 목적 및 항목</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">
+          회사는 다음 목적을 위하여 최소한의 개인정보를 처리합니다.
+        </p>
+        <table className="border border-black w-full text-left">
+          <thead>
+            <tr>
+              <th className="border px-4 py-2">목적</th>
+              <th className="border px-4 py-2">처리 항목(필수)</th>
+              <th className="border px-4 py-2">선택 항목</th>
+              <th className="border px-4 py-2">보유기간</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="border px-4 py-2">회원가입 및 본인확인</td>
+              <td className="border px-4 py-2">이름, 이메일(ID), 비밀번호</td>
+              <td className="border px-4 py-2">프로필 사진, 자기소개, SNS 계정</td>
+              <td className="border px-4 py-2">회원 탈퇴 시까지</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">대학(학력) 인증</td>
+              <td className="border px-4 py-2">소속 학교, 학과(전공), 학교 이메일, 인증 이력</td>
+              <td className="border px-4 py-2">(대체서류: 학생증/재(휴)학·졸업(예정) 증명서)</td>
+              <td className="border px-4 py-2">탈퇴 또는 인증 철회 시까지</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">매칭/계약/정산</td>
+              <td className="border px-4 py-2">성명/회사명, 연락처, (사업자일 경우) 사업자등록정보, 정산 계좌(마스킹 처리)</td>
+              <td className="border px-4 py-2">포트폴리오 정보</td>
+              <td className="border px-4 py-2">전자상거래법에 따른 보관(아래 §6 참조)</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">고객지원 및 분쟁 대응</td>
+              <td className="border px-4 py-2">문의/신고 기록, 채팅/알림 이력</td>
+              <td className="border px-4 py-2">첨부 파일</td>
+              <td className="border px-4 py-2">소비자 분쟁처리 기준에 따른 보관</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">보안 및 서비스 품질 개선</td>
+              <td className="border px-4 py-2">접속 일시, IP주소, 기기정보, 이용기록(로그)</td>
+              <td className="border px-4 py-2">쿠키/행태정보(동의 시)</td>
+              <td className="border px-4 py-2">접속로그 3개월(통신비밀보호법), 기타는 목적 달성 시까지</td>
+            </tr>
+          </tbody>
+        </table>
+        <p className="text-black text-xl pl-4">
+          ※ 선택 항목은 미동의해도 서비스 핵심 이용에는 제한이 없습니다(단, 맞춤 추천 등 일부 기능 제한 가능).
+        </p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">2. 수집 방법</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 회원가입·이용 과정에서 이용자가 직접 입력</p>
+        <p className="text-black text-xl pl-4">- 대학 인증 과정(학교 이메일 인증 또는 대체서류 업로드)</p>
+        <p className="text-black text-xl pl-4">- 서비스 이용 시 자동 수집(접속·로그·쿠키 등)</p>
+        {/* <p className="text-black text-xl pl-4">- 결제·정산 처리 과정에서 결제대행사/정산사로부터 필요한 정보 수신</p> */}
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">3. 제3자 제공</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">
+          회사는 원칙적으로 이용자 동의 없이 개인정보를 제3자에게 제공하지 않습니다. 다만, 다음의 경우에 한합니다.
+        </p>
+        <table className="border border-black w-full text-left">
+          <thead>
+            <tr>
+              <th className="border px-4 py-2">제공받는 자</th>
+              <th className="border px-4 py-2">제공 항목</th>
+              <th className="border px-4 py-2">제공 목적</th>
+              <th className="border px-4 py-2">보유·이용 기간</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="border px-4 py-2">매칭된 기업(수요자) 또는 프리랜서(공급자)</td>
+              <td className="border px-4 py-2">이름/소속/프로필(포트폴리오), 연락수단(플랫폼 내)</td>
+              <td className="border px-4 py-2">프로젝트 제안·계약·협업</td>
+              <td className="border px-4 py-2">매칭 종료 후 1년 또는 동의 철회 시까지</td>
+            </tr>
+            {/* <tr>
+              <td className="border px-4 py-2">결제대행사(KG이니시스)</td>
+              <td className="border px-4 py-2">결제 식별자, 결제 수단 일부 정보, 결제/취소 이력</td>
+              <td className="border px-4 py-2">결제·환불·부정거래 방지</td>
+              <td className="border px-4 py-2">관련 법령 및 계약에 따름</td>
+            </tr> */}
+          </tbody>
+        </table>
+        <p className="text-black text-xl pl-4">
+          ※ 제3자 제공은 선택 동의 기반이며, 미동의 시 일부 기능(매칭 제안 등)에 제한이 있을 수 있습니다.
+        </p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">4. 처리의 위탁(수탁자)</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">안전하고 효율적인 서비스 제공을 위해 다음 업체에 업무를 위탁할 수 있습니다.</p>
+        <table className="border border-black w-full text-left">
+          <thead>
+            <tr>
+              <th className="border px-4 py-2">수탁자</th>
+              <th className="border px-4 py-2">위탁업무</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="border px-4 py-2">아마존웹서비스(AWS)</td>
+              <td className="border px-4 py-2">인프라 호스팅, 데이터 보관(리전: 서울/ap-northeast-2)</td>
+            </tr>
+            {/* <tr>
+              <td className="border px-4 py-2">KG 이니시스</td>
+              <td className="border px-4 py-2">전자지급결제대행(PG), 결제창 제공, 결제 승인/매입/정산, 환불·부분취소 처리, 에스크로(대금예치) 운영, 현금영수증/카드전표 발급, 부정거래 탐지(FDS)</td>
+            </tr> */}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">5. 국외 이전</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">해당 없음</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">6. 법정 보관기간</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">전자상거래 등에서의 소비자보호에 관한 법률에 따라 아래 정보는 법정 기간 보관합니다.</p>
+        <p className="text-black text-xl pl-4">- 계약 또는 청약철회 기록: 5년</p>
+        {/* <p className="text-black text-xl pl-4">- 대금결제 및 재화 등의 공급 기록: 5년</p> */}
+        <p className="text-black text-xl pl-4">- 소비자 불만 또는 분쟁처리 기록: 3년</p>
+        <p className="text-black text-xl pl-4">- 표시·광고에 관한 기록: 6개월</p>
+        <p className="text-black text-xl pl-4">- 접속로그: 3개월(통신비밀보호법)</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">7. 이용자 권리와 행사방법</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 본인·대리인은 언제든지 개인정보 열람·정정·삭제·처리정지 요구 가능</p>
+        <p className="text-black text-xl pl-4">- 앱/웹 마이페이지 및 고객센터를 통해 요청 가능하며, 회사는 법령이 정한 기간 내 처리</p>
+        <p className="text-black text-xl pl-4">- 만 14세 미만 아동의 경우 법정대리인의 동의를 받아 처리</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">8. 쿠키 및 행태정보</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 회사는 서비스 개선과 맞춤형 제공을 위해 쿠키를 사용할 수 있으며, 이용자는 브라우저 설정으로 저장을 거부할 수 있습니다.</p>
+        <p className="text-black text-xl pl-4">- 온라인 맞춤형 광고/행태정보 수집 운영 시 수집 항목·목적·보유기간·거부 방법을 별도로 고지하며, 미사용 시 “운영하지 않음” 표기</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">9. 파기절차 및 방법</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 보유기간 경과·처리 목적 달성 시 지체 없이 파기</p>
+        <p className="text-black text-xl pl-4">- 전자파일은 복구 불가능한 방법으로 삭제, 출력물은 분쇄 또는 소각</p>
+        <p className="text-black text-xl pl-4">- 일부 정보는 법령상 보관 의무에 따라 별도 분리 보관 후 파기</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">10. 안전성 확보조치</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 관리적 조치: 내부관리계획 수립·시행, 최소권한 관리, 정기 교육</p>
+        <p className="text-black text-xl pl-4">- 기술적 조치: 암호화 저장(비밀번호 해시), 전송 구간 암호화(TLS), 접근통제(IAM), 이상징후 모니터링</p>
+        <p className="text-black text-xl pl-4">- 개인정보 유출 통지: 유출 또는 침해 사실 인지 시 법령에 따라 지체 없이 통지·신고</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">11. 개인정보 보호책임자</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 보호책임자: 박정곤</p>
+        <p className="text-black text-xl pl-4">- 이메일: <a href="mailto:souf-official@souf.co.kr" className="underline text-blue-600">souf-official@souf.co.kr</a></p>
+        <p className="text-black text-xl pl-4">- 주소: 서울특별시 광진구 광나루로19길 23, 103호</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">13. 권익침해 구제방법</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 개인정보 침해 상담·신고: 개인정보침해신고센터(118), 개인정보분쟁조정위원회(1833-6972)</p>
+        <p className="text-black text-xl pl-4">- 대검찰청 사이버수사과(1301), 경찰청 사이버수사국(182)</p>
+      </div>
+
+      <h3 className="text-black font-semibold text-3xl mb-6 mt-10">14. 고지의 의무</h3>
+      <div className="flex flex-col gap-4">
+        <p className="text-black text-xl pl-4">- 본 방침은 [시행일자]부터 적용됩니다. 내용 추가·삭제·수정이 있을 경우 시행 7일 전부터 공지</p>
+        <p className="text-black text-xl pl-4">- 최초 시행: 2025. 08. 06</p>
+        <p className="text-black text-xl pl-4">- 최근 개정: 2025. 10. 19</p>
+      </div>
+        </div>
+    )
+}

--- a/src/pages/policy/terms.jsx
+++ b/src/pages/policy/terms.jsx
@@ -1,0 +1,124 @@
+export default function TermsPage() {
+  return  (
+  <div className="max-w-[60rem] w-full mx-auto px-4 mt-12 mb-20">
+    <h2 className="text-black font-bold text-4xl mb-6">이용약관</h2>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제1조 (목적)</h3>
+  <p className="text-black text-xl pl-4">
+    이 약관은 대학생이 자신의 포트폴리오 및 작업물을 게시하고, 기업이 채용 공고를 등록하며, 양측이 상호 소통하는 온라인 플랫폼 서비스의 이용에 관한 회사와 회원 간의 권리·의무 및 책임사항을 규정합니다.
+  </p>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제2조 (용어의 정의)</h3>
+  <div className="flex flex-col gap-4">
+    <p className="text-black text-xl pl-4">
+    이 약관에서 정하는 용어의 정의는 다음과 같습니다.
+    </p>
+  <p className="text-black text-xl pl-4">
+  ① 스프(SouF) 회사가 제공하는 서비스에 가입한 자(기업·소상공인·개인사업자·프리랜서 포함)를 회원이라 하며, 회원 중 프로젝트를 의뢰하고 대금을 지급하는 자를 발주자(수요자/의뢰자)라 하고, 프로젝트를 수행하는 자를 수급자(공급자/프리랜서/대학생 프리랜서)라 합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ② 프로젝트(외주)란 플랫폼을 통해 체결·수행되는 업무를 의미하며, 표준 계약서는 회사가 제공하는 외주 표준계약을 말합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ④ 검수 승인 또는 자동 승인은 결과물 승인 또는 기한 경과에 따른 승인을 말하며, 중도해지는 계약 기간 중 당사자가 계약을 해지하는 행위를 의미합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ④ 예치 잔금 반환(환불)은 프로젝트가 미완료되거나 중단될 경우 예치된 잔금을 반환하는 것을 말합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ⑤ 전자서명은 전자적 방식으로 서명·동의하는 행위를 의미합니다.
+      </p>
+      <p className="text-black text-xl pl-4">
+      ⑥ 제3자 제공 또는 처리위탁(수탁자)은 개인정보처리방침에서 쓰는 법정 용어를 의미하며, 서비스 제공기간은 결제일로부터 최대 180일을 말합니다.
+      </p>
+
+  </div>
+  
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제3조 (약관의 효력 및 변경)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 본 약관은 회사가 서비스 화면에 게시하거나 기타 방법으로 회원에게 공지함으로써 효력을 발생합니다.</p>
+  <p className="text-black text-xl pl-4">2. 회사는 관련 법령을 위배하지 않는 범위에서 약관을 개정할 수 있으며, 개정 시 개정사유와 시행일자를 명시하여 최소 7일 전 공지합니다.</p>
+  <p className="text-black text-xl pl-4">3. 회원이 개정된 약관에 대해 명시적으로 거부 의사를 표시하지 않고 계속 서비스를 이용하는 경우, 개정 약관에 동의한 것으로 간주합니다.</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제4조 (서비스 이용 계약의 체결)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회원가입은 이용자가 본 약관 및 개인정보처리방침에 동의하고, 회사가 정한 절차에 따라 회원가입 신청을 완료한 후 회사가 이를 승인함으로써 체결됩니다.</p>
+  <p className="text-black text-xl pl-4">2. 회사는 다음 각 호에 해당하는 경우 이용 신청을 승낙하지 않을 수 있습니다.</p>
+  <p className="text-black text-xl pl-4">- 실명이 아니거나 타인의 명의를 도용한 경우</p>
+  <p className="text-black text-xl pl-4">- 허위 정보를 입력한 경우</p>
+  <p className="text-black text-xl pl-4">- 기타 회사의 운영정책에 위배되는 행위</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제5조 (서비스의 내용)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회사는 다음과 같은 서비스를 제공합니다.</p>
+  <p className="text-black text-xl pl-4">- 학생회원의 포트폴리오 등록, 관리 및 공개</p>
+  <p className="text-black text-xl pl-4">- 기업회원의 공고문 작성 및 노출</p>
+  <p className="text-black text-xl pl-4">- 포트폴리오 및 공고에 대한 상호 피드백, 댓글, 스크랩 등 SNS 기능</p>
+  <p className="text-black text-xl pl-4">- 광고 콘텐츠의 제공 및 노출</p>
+  <p className="text-black text-xl pl-4">- 향후 결제 시스템을 통한 유료 콘텐츠, 유료 채용 홍보 등 기능</p>
+  <p className="text-black text-xl pl-4">2. 회사는 서비스 일부를 광고 기반으로 운영할 수 있으며, 회원은 광고 노출에 동의하는 것으로 간주됩니다.</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제6조 (회원의 의무)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회원은 서비스 이용 시 다음 각 호의 행위를 하여서는 안 됩니다.</p>
+  <p className="text-black text-xl pl-4">- 허위 정보 등록 또는 타인 정보 도용</p>
+  <p className="text-black text-xl pl-4">- 타인의 지식재산권, 초상권 등 권리를 침해하는 행위</p>
+  <p className="text-black text-xl pl-4">- 불쾌감 또는 혐오감을 주는 게시물 등록</p>
+  <p className="text-black text-xl pl-4">- 광고, 스팸 등 상업적 목적의 콘텐츠 무단 게시</p>
+  <p className="text-black text-xl pl-4">- 서비스의 정상적 운영을 방해하는 행위</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제7조 (회사의 권리와 의무)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회사는 안정적인 서비스 제공을 위해 노력하며, 시스템 유지·보수 등의 사유로 일시적 중단이 있을 수 있습니다.</p>
+  <p className="text-black text-xl pl-4">2. 회사는 회원이 등록한 콘텐츠를 사전 승인 없이 내부 홍보, 추천, 큐레이션 목적으로 활용할 수 있습니다.</p>
+  <p className="text-black text-xl pl-4">3. 회사는 회원이 약관 위반 시, 사전 고지 없이 콘텐츠 삭제, 서비스 이용 제한, 회원 자격 박탈 등의 조치를 취할 수 있습니다.</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제8조 (지적재산권)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회원이 서비스에 등록한 콘텐츠에 대한 저작권은 해당 회원에게 있으며, 회사는 해당 콘텐츠를 서비스 운영 및 홍보 목적으로 사용할 수 있습니다.</p>
+  <p className="text-black text-xl pl-4">2. 회원은 콘텐츠를 등록함으로써, 회사에 비독점적·무상·재사용 가능한 이용 권한을 부여한 것으로 간주됩니다.</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제9조 (광고 및 유료서비스)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회사는 서비스 내에 제3자의 광고를 게재할 수 있으며, 회원은 이에 대해 동의합니다.</p>
+  <p className="text-black text-xl pl-4">2. 유료 서비스 도입 시, 가격, 결제 수단, 환불 정책 등은 별도의 고지 및 동의 절차를 거쳐 운영됩니다.</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제10조 (서비스의 해지 및 탈퇴)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회원은 언제든지 서비스 내 제공되는 메뉴를 통해 이용계약을 해지할 수 있습니다.</p>
+  <p className="text-black text-xl pl-4">2. 회사는 다음 각 호에 해당하는 경우 사전 통보 없이 이용계약을 해지할 수 있습니다.</p>
+  <p className="text-black text-xl pl-4">- 본 약관 또는 관련 법령을 위반한 경우</p>
+  <p className="text-black text-xl pl-4">- 타인의 권리를 침해하거나 공공질서를 해친 경우</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제11조 (면책조항)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회사는 천재지변, 시스템 장애 등 불가항력 사유로 인한 서비스 중단에 대해 책임을 지지 않습니다.</p>
+  <p className="text-black text-xl pl-4">2. 회사는 회원 간 거래, 커뮤니케이션에 개입하지 않으며, 그 분쟁에 대해서는 책임을 지지 않습니다.</p>
+
+  </div>
+
+  <h3 className="text-black font-semibold text-3xl mb-6 mt-10">제12조 (준거법 및 관할)</h3>
+  <div className="flex flex-col gap-4">
+  <p className="text-black text-xl pl-4">1. 회사와 회원 간 분쟁이 발생할 경우, 양 당사자는 분쟁 해결을 위해 협의할 수 있습니다.</p>
+  <p className="text-black text-xl pl-4">2. 분쟁 조정이 어려울 경우, 본 약관은 대한민국 법령에 따라 해석되며, 회사와 회원 간 분쟁 발생 시 회사의 본사 소재지를 관할하는 법원을 제1심 관할 법원으로 합니다.</p>
+  </div>
+ 
+</div>
+  );
+}

--- a/src/pages/recruitDetails.jsx
+++ b/src/pages/recruitDetails.jsx
@@ -503,7 +503,7 @@ export default function RecruitDetail() {
             )}
 
           </div>
-          <p className="text-sm text-neutral-500 my-4">서비스 상품 교환 및 환불 규정 등은 결제·정산·환불(에스크로) 정책을 참고해주세요.</p>
+          {/* <p className="text-sm text-neutral-500 my-4">서비스 상품 교환 및 환불 규정 등은 결제·정산·환불(에스크로) 정책을 참고해주세요.</p> */}
           {/* <RecommendRecruit /> */}
           <EstimateBanner color="blue" />
 

--- a/src/pages/recruitUpload.jsx
+++ b/src/pages/recruitUpload.jsx
@@ -1200,7 +1200,7 @@ export default function RecruitUpload() {
             LAST STEP . 
             {/* <img src={infoIcon} alt="infoIcon" className="w-4 h-4 cursor-pointer" /> */}
         </div>
-        <p className="text-sm text-neutral-500 mb-8">서비스 상품 교환 및 환불 규정 등은 결제·정산·환불(에스크로) 정책을 참고해주세요.</p>
+        {/* <p className="text-sm text-neutral-500 mb-8">서비스 상품 교환 및 환불 규정 등은 결제·정산·환불(에스크로) 정책을 참고해주세요.</p> */}
 
         <div className="flex gap-4 items-center justify-center">
         <button

--- a/src/router/router.jsx
+++ b/src/router/router.jsx
@@ -33,7 +33,10 @@ import Inspection from "../pages/inspection";
 import { HelmetProvider } from 'react-helmet-async';
 import FloatingChatButton from "../components/floatingChatButton";
 import AlertModal from "../components/alertModal";
-import Page1 from "../pages/policy/page1";
+import TermsPage from "../pages/policy/terms";
+import PrivacyPage from "../pages/policy/privacy";
+import ComplainPage from "../pages/policy/complain";
+
 function AppRouter() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -87,7 +90,9 @@ function AppRouter() {
           <Route path="/withdraw" element={<Withdraw/>} />
           <Route path="/forbidden" element={<Forbidden/>} />
           <Route path="/guide" element={<CsPage/>} />
-          <Route path="/policy/page1" element={<Page1/>} />
+          <Route path="/policy/terms" element={<TermsPage/>} />
+          <Route path="/policy/privacy" element={<PrivacyPage/>} />
+          <Route path="/policy/complaintDispute" element={<ComplainPage/>} />
         </Routes>
       </main>
       {!isChatPage && <Footer />}


### PR DESCRIPTION


## 🛠️ 작업 내용

> 이용약관&개인정보처리방침&분쟁처리방침 페이지 구현

Footer의 이용약관, 개인정보처리방침, 분쟁처리방침 을 클릭하면 해당 내용을 담은 페이지가 나오도록 구현했습니다. 내용은 기존 노션의 내용과 동일합니다.

## 📸 스크린샷
1. 이용약관 페이지
<img width="816" height="842" alt="image" src="https://github.com/user-attachments/assets/ffdbfb45-67cc-4acb-ad6c-ec5fc71472af" />

2. 개인정보처리방침 페이지
<img width="838" height="830" alt="image" src="https://github.com/user-attachments/assets/29720f7b-5519-42b5-8fe8-74d5f4d29a74" />

3. 분쟁처리방침 페이지
<img width="819" height="858" alt="image" src="https://github.com/user-attachments/assets/91ebc905-6bdb-4bae-87db-bcc756943cb4" />




