### PR TITLE
FIX : sitemap 경로 변경

### DIFF
--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -191,6 +191,6 @@ async function fetchAllRecruits() {
 
   smStream.end();
   const sitemap = await streamToPromise(smStream).then(sm => sm.toString());
-  fs.writeFileSync("./public/sitemap.xml", sitemap);
+  fs.writeFileSync("./dist/sitemap.xml", sitemap);
   console.log("sitemap.xml 생성 완료!");
 })();


### PR DESCRIPTION
/public/sitemap.xml 로 설정했을때 터미널 확인 결과

```
base) tldms@MacBookiOnAndOn Souf-FE % curl -I https://www.souf.co.kr/sitemap.xml 
HTTP/2 200 
content-type: text/html
```
로 확인되어 홈 화면으로 리다이렉트되는 문제가 발생해 
build 후 dist에 생성되게 하기 위해 경로를 변경했습니다. 